### PR TITLE
Fix for issue #27 (nuget update of WebApi removes Exceptionless module)

### DIFF
--- a/Source/Platforms/Mvc/NuGet/tools/uninstall.ps1
+++ b/Source/Platforms/Mvc/NuGet/tools/uninstall.ps1
@@ -5,5 +5,5 @@ Import-Module (Join-Path $toolsPath exceptionless.psm1)
 $configPath = find_config $project
 
 if ($configPath -ne $null) {
-	remove_config $configPath
+	remove_config $configPath 'Mvc'
 }

--- a/Source/Platforms/Web/NuGet/tools/uninstall.ps1
+++ b/Source/Platforms/Web/NuGet/tools/uninstall.ps1
@@ -5,5 +5,5 @@ Import-Module (Join-Path $toolsPath exceptionless.psm1)
 $configPath = find_config $project
 
 if ($configPath -ne $null) {
-	remove_config $configPath
+	remove_config $configPath 'Web'
 }

--- a/Source/Platforms/WebApi/NuGet/tools/uninstall.ps1
+++ b/Source/Platforms/WebApi/NuGet/tools/uninstall.ps1
@@ -5,5 +5,5 @@ Import-Module (Join-Path $toolsPath exceptionless.psm1)
 $configPath = find_config $project
 
 if ($configPath -ne $null) {
-	remove_config $configPath
+	remove_config $configPath 'WebApi'
 }

--- a/Source/Shared/NuGet/tools/exceptionless.psm1
+++ b/Source/Shared/NuGet/tools/exceptionless.psm1
@@ -106,7 +106,7 @@ function update_config($configPath, $platform) {
 	}
 }
 
-function remove_config($configPath) {
+function remove_config($configPath, $platform) {
 	[xml] $configXml = gc $configPath
 	$shouldSave = $false
 
@@ -127,16 +127,18 @@ function remove_config($configPath) {
 			}
 		}
 		
-		$webModule = $configXml.SelectSingleNode("configuration/system.web/httpModules/add[@name='ExceptionlessModule']")
-		if ($webModule -ne $null) {
-			[Void]$webModule.ParentNode.RemoveChild($webModule)
-			$shouldSave = $true
-		}
+		if ($platform -ne $null -and $platform -ne 'WebApi') {
+			$webModule = $configXml.SelectSingleNode("configuration/system.web/httpModules/add[@name='ExceptionlessModule']")
+			if ($webModule -ne $null) {
+				[Void]$webModule.ParentNode.RemoveChild($webModule)
+				$shouldSave = $true
+			}
 		
-		$webServerModule = $configXml.SelectSingleNode("configuration/system.webServer/modules/add[@name='ExceptionlessModule']")
-		if ($webServerModule -ne $null) {
-			[Void]$webServerModule.ParentNode.RemoveChild($webServerModule)
-			$shouldSave = $true
+			$webServerModule = $configXml.SelectSingleNode("configuration/system.webServer/modules/add[@name='ExceptionlessModule']")
+			if ($webServerModule -ne $null) {
+				[Void]$webServerModule.ParentNode.RemoveChild($webServerModule)
+				$shouldSave = $true
+			}
 		}
 		
 		


### PR DESCRIPTION
Pass the platform from uninstall.ps1 to remove_config function, and use
the same rules to delete the ExceptionlessModule from
system.web/httpModules and system.webServer/modules as were used to
insert