### PR TITLE
Pull request for  #37 Added the ability to read settings from environmental variables.

### DIFF
--- a/Source/Extras/Extensions/ExceptionlessExtraConfigurationExtensions.cs
+++ b/Source/Extras/Extensions/ExceptionlessExtraConfigurationExtensions.cs
@@ -176,7 +176,7 @@ namespace Exceptionless {
             
             string serverUrl = ConfigurationManager.AppSettings["Exceptionless:ServerUrl"];
             if (!String.IsNullOrEmpty(serverUrl))
-                config.ApiKey = serverUrl;
+                config.ServerUrl = serverUrl;
         }
 
         /// <summary>
@@ -194,7 +194,7 @@ namespace Exceptionless {
             
             string serverUrl = GetEnvironmentalVariable("Exceptionless:ServerUrl");
             if (!String.IsNullOrEmpty(serverUrl))
-                config.ApiKey = serverUrl;
+                config.ServerUrl = serverUrl;
         }
 
         private static string GetEnvironmentalVariable(string name) {

--- a/Source/Extras/Extensions/ExceptionlessExtraConfigurationExtensions.cs
+++ b/Source/Extras/Extensions/ExceptionlessExtraConfigurationExtensions.cs
@@ -173,10 +173,6 @@ namespace Exceptionless {
             bool enabled;
             if (Boolean.TryParse(ConfigurationManager.AppSettings["Exceptionless:Enabled"], out enabled))
                 config.Enabled = enabled;
-
-            bool enableSSL;
-            if (Boolean.TryParse(ConfigurationManager.AppSettings["Exceptionless:EnableSSL"], out enableSSL))
-                config.EnableSSL = enableSSL;
             
             string serverUrl = ConfigurationManager.AppSettings["Exceptionless:ServerUrl"];
             if (!String.IsNullOrEmpty(serverUrl))
@@ -195,11 +191,7 @@ namespace Exceptionless {
             bool enabled;
             if (Boolean.TryParse(GetEnvironmentalVariable("Exceptionless:Enabled"), out enabled))
                 config.Enabled = enabled;
-
-            bool enableSSL;
-            if (Boolean.TryParse(GetEnvironmentalVariable("Exceptionless:EnableSSL"), out enableSSL))
-                config.EnableSSL = enableSSL;
-
+            
             string serverUrl = GetEnvironmentalVariable("Exceptionless:ServerUrl");
             if (!String.IsNullOrEmpty(serverUrl))
                 config.ApiKey = serverUrl;

--- a/Source/Extras/Extensions/ExceptionlessExtraConfigurationExtensions.cs
+++ b/Source/Extras/Extensions/ExceptionlessExtraConfigurationExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Configuration;
 using System.Diagnostics;
 using System.IO;
@@ -15,6 +17,8 @@ using Exceptionless.Storage;
 
 namespace Exceptionless {
     public static class ExceptionlessExtraConfigurationExtensions {
+        private static Dictionary<string, string> _environmentVariables;
+
         /// <summary>
         /// Reads the Exceptionless configuration from the app.config or web.config file.
         /// </summary>
@@ -72,15 +76,10 @@ namespace Exceptionless {
         }
 
         /// <summary>
-        /// Reads the Exceptionless configuration from the app.config or web.config file.
+        /// Reads the Exceptionless configuration from the app.config or web.config files configuration section.
         /// </summary>
         /// <param name="config">The configuration object you want to apply the attribute settings to.</param>
         public static void ReadFromConfigSection(this ExceptionlessConfiguration config) {
-            // If an appsetting is present for ApiKey, then it will override the other api keys
-            string apiKeyOverride = ConfigurationManager.AppSettings["Exceptionless:ApiKey"];
-            if (IsValidApiKey(apiKeyOverride))
-                config.ApiKey = apiKeyOverride;
-
             ExceptionlessSection section = null;
 
             try {
@@ -93,9 +92,8 @@ namespace Exceptionless {
                 return;
 
             config.Enabled = section.Enabled;
-
-            // Only update if it hasn't already been set via app settings.
-            if (!IsValidApiKey(apiKeyOverride) && IsValidApiKey(section.ApiKey))
+            
+            if (IsValidApiKey(section.ApiKey))
                 config.ApiKey = section.ApiKey;
             
             if (!String.IsNullOrEmpty(section.ServerUrl))
@@ -159,6 +157,69 @@ namespace Exceptionless {
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Reads the Exceptionless configuration from the app.config or web.config files app settings.
+        /// </summary>
+        /// <param name="config">The configuration object you want to apply the attribute settings to.</param>
+        public static void ReadFromAppSettings(this ExceptionlessConfiguration config) {
+            string apiKey = ConfigurationManager.AppSettings["Exceptionless:ApiKey"];
+            if (IsValidApiKey(apiKey))
+                config.ApiKey = apiKey;
+
+            bool enabled;
+            if (Boolean.TryParse(ConfigurationManager.AppSettings["Exceptionless:Enabled"], out enabled))
+                config.Enabled = enabled;
+
+            bool enableSSL;
+            if (Boolean.TryParse(ConfigurationManager.AppSettings["Exceptionless:EnableSSL"], out enableSSL))
+                config.EnableSSL = enableSSL;
+            
+            string serverUrl = ConfigurationManager.AppSettings["Exceptionless:ServerUrl"];
+            if (!String.IsNullOrEmpty(serverUrl))
+                config.ApiKey = serverUrl;
+        }
+
+        /// <summary>
+        /// Reads the Exceptionless configuration from Environment Variables.
+        /// </summary>
+        /// <param name="config">The configuration object you want to apply the attribute settings to.</param>
+        public static void ReadFromEnvironmentalVariables(this ExceptionlessConfiguration config) {
+            string apiKey = GetEnvironmentalVariable("Exceptionless:ApiKey");
+            if (IsValidApiKey(apiKey))
+                config.ApiKey = apiKey;
+
+            bool enabled;
+            if (Boolean.TryParse(GetEnvironmentalVariable("Exceptionless:Enabled"), out enabled))
+                config.Enabled = enabled;
+
+            bool enableSSL;
+            if (Boolean.TryParse(GetEnvironmentalVariable("Exceptionless:EnableSSL"), out enableSSL))
+                config.EnableSSL = enableSSL;
+
+            string serverUrl = GetEnvironmentalVariable("Exceptionless:ServerUrl");
+            if (!String.IsNullOrEmpty(serverUrl))
+                config.ApiKey = serverUrl;
+        }
+
+        private static string GetEnvironmentalVariable(string name) {
+            if (String.IsNullOrEmpty(name))
+                return null;
+            
+            if (_environmentVariables == null) {
+                try {
+                    _environmentVariables = Environment.GetEnvironmentVariables().Cast<DictionaryEntry>().ToDictionary(e => e.Key.ToString(), e => e.Value.ToString());
+                } catch (Exception ex) {
+                    _environmentVariables = new Dictionary<string, string>();
+                    return null;
+                }
+            }
+            
+            if (!_environmentVariables.ContainsKey(name))
+                return null;
+
+            return _environmentVariables[name];
         }
 
         private static bool IsValidApiKey(string apiKey) {

--- a/Source/Extras/Extensions/ExceptionlessExtraConfigurationExtensions.cs
+++ b/Source/Extras/Extensions/ExceptionlessExtraConfigurationExtensions.cs
@@ -72,6 +72,8 @@ namespace Exceptionless {
                 config.ReadFromAttributes(configAttributesAssemblies);
 
             config.ReadFromConfigSection();
+            config.ReadFromAppSettings();
+            config.ReadFromEnvironmentalVariables();
             config.ApplySavedServerSettings();
         }
 

--- a/Source/Shared/Configuration/ExceptionlessAttribute.cs
+++ b/Source/Shared/Configuration/ExceptionlessAttribute.cs
@@ -32,6 +32,7 @@ namespace Exceptionless.Configuration {
         /// </summary>
         /// ///
         /// <value><c>true</c> to enable SSL; otherwise, <c>false</c>.</value>
+        [ObsoleteAttribute("This property will be removed in a future release.")]
         public bool EnableSSL { get; set; }
 
         /// <summary>

--- a/Source/Shared/Configuration/ExceptionlessConfiguration.cs
+++ b/Source/Shared/Configuration/ExceptionlessConfiguration.cs
@@ -97,6 +97,7 @@ namespace Exceptionless {
         /// <summary>
         /// Whether or not the client should use SSL when communicating with the server.
         /// </summary>
+        [ObsoleteAttribute("This property will be removed in a future release.")]
         public bool EnableSSL { get; set; }
 
         /// <summary>


### PR DESCRIPTION
I noticed there was a race condition that may be reintroduced here https://github.com/exceptionless/Exceptionless.Net/commit/da1f9f3ff00ea0fe8076d27d6a519811e2cf4ba0. However, I now think it's caused by the http modules calling startup multiple times and an exception happening.

@ejsmith :

1. Should we add checks to the modules to ensure init only happens once?
2. The environmental variable names are consistent with the app settings variables... Do you like this name?
3. Do you think we should drop enable ssl? To me it should be determined if you have https or http defined as part of the server url and we shouldn't be changing the url..