### PR TITLE
Fixed an issue with self hosted installs that used AppSettings.

### DIFF
--- a/Source/Samples/SampleMvc/Exceptionless.SampleMvc.csproj
+++ b/Source/Samples/SampleMvc/Exceptionless.SampleMvc.csproj
@@ -24,6 +24,7 @@
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>5ce62974</NuGetPackageImportStamp>
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -119,7 +120,7 @@
     <Reference Include="System.EnterpriseServices" />
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http">
     </Reference>

--- a/Source/Samples/SampleMvc/Web.config
+++ b/Source/Samples/SampleMvc/Web.config
@@ -4,15 +4,10 @@
   http://go.microsoft.com/fwlink/?LinkId=152368
   -->
 <configuration>
-  <configSections>
-    <section name="exceptionless" type="Exceptionless.ExceptionlessSection, Exceptionless.Extras" />
-  </configSections>
-  <exceptionless apiKey="LhhP1C9gijpSKCslHHCvwdSIz298twx271n1l6xw" serverUrl="http://localhost:50000" enableSSL="false" tags="Europe">
-    <settings>
-      <add name="TraceLogLimit" value="30" />
-    </settings>
-  </exceptionless>
   <appSettings>
+    <add key="Exceptionless:ApiKey" value="LhhP1C9gijpSKCslHHCvwdSIz298twx271n1l6xw" />
+    <add key="Exceptionless:ServerUrl" value="http://localhost:50000" />
+    
     <add key="webpages:Version" value="3.0.0.0" />
     <add key="webpages:Enabled" value="false" />
   </appSettings>
@@ -39,8 +34,6 @@
       <remove name="ExceptionlessModule" />
       <add name="ExceptionlessModule" type="Exceptionless.Mvc.ExceptionlessModule, Exceptionless.Mvc" />
     </modules>
-
-    
   <handlers>
       <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
       <remove name="OPTIONSVerbHandler" />

--- a/Source/Shared/Extensions/ExceptionlessConfigurationExtensions.cs
+++ b/Source/Shared/Extensions/ExceptionlessConfigurationExtensions.cs
@@ -138,10 +138,8 @@ namespace Exceptionless.Extensions {
             builder.Path += builder.Path.EndsWith("/") ? "api/v2/" : "/api/v2/";
 
             // EnableSSL
-            if (config.EnableSSL && builder.Port == 80 && !builder.Host.Contains("local")) {
+            if (builder.Scheme == "https" && builder.Port == 80 && !builder.Host.Contains("local"))
                 builder.Port = 443;
-                builder.Scheme = "https";
-            }
 
             return builder.Uri;
         }


### PR DESCRIPTION
The scheme would be set to 443 always when it shouldn't of been set.
This code is now driven off of the scheme specified. @ejsmith  I don't
even think we need this code block anymore because the underlying uri
parser looks to be setting the port correctly based on the scheme.