### PR TITLE
add missing Reference Include

### DIFF
--- a/Source/Tests/Exceptionless.Tests.csproj
+++ b/Source/Tests/Exceptionless.Tests.csproj
@@ -100,6 +100,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
+    <Reference Include="System.Runtime" />
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>


### PR DESCRIPTION
When I first cloned the repository, the Exceptionless.Tests did not compile due to a missing reference to System.Runtime
