### PR TITLE
Persistent Queue Fix

### DIFF
--- a/Source/Extras/Exceptionless.Extras.csproj
+++ b/Source/Extras/Exceptionless.Extras.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Net.Http.dll</HintPath>

--- a/Source/Extras/ExceptionlessSection.cs
+++ b/Source/Extras/ExceptionlessSection.cs
@@ -24,6 +24,9 @@ namespace Exceptionless {
         [ConfigurationProperty("storagePath")]
         public string StoragePath { get { return base["storagePath"] as string; } set { base["storagePath"] = value; } }
 
+        [ConfigurationProperty("persistQueue")]
+        public bool? PersistQueue { get { return (bool?)base["persistQueue"]; } set { base["persistQueue"] = value; } }
+
         [ConfigurationProperty("tags")]
         public string Tags { get { return this["tags"] as string; } set { this["tags"] = value; } }
 

--- a/Source/Extras/Extensions/ExceptionlessExtraConfigurationExtensions.cs
+++ b/Source/Extras/Extensions/ExceptionlessExtraConfigurationExtensions.cs
@@ -29,7 +29,7 @@ namespace Exceptionless {
         }
 
         public static void UseIsolatedStorage(this ExceptionlessConfiguration config) {
-            config.Resolver.Register<IObjectStorage, IsolatedStorageObjectStorage>();
+            config.Resolver.Register<IObjectStorage>(new IsolatedStorageObjectStorage(config.Resolver));
         }
 
         public static void UseFolderStorage(this ExceptionlessConfiguration config, string folder) {
@@ -94,6 +94,8 @@ namespace Exceptionless {
                 return;
 
             config.Enabled = section.Enabled;
+
+            config.PersistQueue = section.PersistQueue ?? true;
             
             if (IsValidApiKey(section.ApiKey))
                 config.ApiKey = section.ApiKey;
@@ -177,6 +179,10 @@ namespace Exceptionless {
             string serverUrl = ConfigurationManager.AppSettings["Exceptionless:ServerUrl"];
             if (!String.IsNullOrEmpty(serverUrl))
                 config.ServerUrl = serverUrl;
+
+            bool persistQueue;
+            if (Boolean.TryParse(ConfigurationManager.AppSettings["Exceptionless:PersistQueue"], out persistQueue))
+                config.PersistQueue = persistQueue;
         }
 
         /// <summary>
@@ -195,6 +201,10 @@ namespace Exceptionless {
             string serverUrl = GetEnvironmentalVariable("Exceptionless:ServerUrl");
             if (!String.IsNullOrEmpty(serverUrl))
                 config.ServerUrl = serverUrl;
+
+            bool persistQueue;
+            if (Boolean.TryParse(GetEnvironmentalVariable("Exceptionless:PersistQueue"), out persistQueue))
+                config.PersistQueue = persistQueue;
         }
 
         private static string GetEnvironmentalVariable(string name) {

--- a/Source/Extras/Submission/SubmissionClient.cs
+++ b/Source/Extras/Submission/SubmissionClient.cs
@@ -30,16 +30,16 @@ namespace Exceptionless.Extras.Submission {
                 if (ex != null)
                     response = (HttpWebResponse)ex.Response;
                 else
-                    return new SubmissionResponse(500, message: aex.GetMessage());
+                    return new SubmissionResponse(HttpStatusCode.InternalServerError, message: aex.GetMessage());
             } catch (Exception ex) {
-                return new SubmissionResponse(500, message: ex.Message);
+                return new SubmissionResponse(HttpStatusCode.InternalServerError, message: ex.Message);
             }
 
             int settingsVersion;
             if (Int32.TryParse(response.Headers[ExceptionlessHeaders.ConfigurationVersion], out settingsVersion))
                 SettingsManager.CheckVersion(settingsVersion, config);
 
-            return new SubmissionResponse((int)response.StatusCode, GetResponseMessage(response));
+            return new SubmissionResponse(response.StatusCode, GetResponseMessage(response));
         }
 
         public SubmissionResponse PostUserDescription(string referenceId, UserDescription description, ExceptionlessConfiguration config, IJsonSerializer serializer) {
@@ -54,16 +54,16 @@ namespace Exceptionless.Extras.Submission {
                 if (ex != null)
                     response = (HttpWebResponse)ex.Response;
                 else
-                    return new SubmissionResponse(500, message: aex.GetMessage());
+                    return new SubmissionResponse(HttpStatusCode.InternalServerError, message: aex.GetMessage());
             } catch (Exception ex) {
-                return new SubmissionResponse(500, message: ex.Message);
+                return new SubmissionResponse(HttpStatusCode.InternalServerError, message: ex.Message);
             }
 
             int settingsVersion;
             if (Int32.TryParse(response.Headers[ExceptionlessHeaders.ConfigurationVersion], out settingsVersion))
                 SettingsManager.CheckVersion(settingsVersion, config);
 
-            return new SubmissionResponse((int)response.StatusCode, GetResponseMessage(response));
+            return new SubmissionResponse(response.StatusCode, GetResponseMessage(response));
         }
 
         public SettingsResponse GetSettings(ExceptionlessConfiguration config, IJsonSerializer serializer) {

--- a/Source/Samples/SampleConsole/Submission/InMemorySubmissionClient.cs
+++ b/Source/Samples/SampleConsole/Submission/InMemorySubmissionClient.cs
@@ -3,14 +3,17 @@ using System.Collections.Generic;
 using Exceptionless.Models;
 using Exceptionless.Models.Data;
 using Exceptionless.Submission;
+using System.Net;
 
 namespace Exceptionless.SampleConsole
 {
-    public class InMemorySubmissionClient: ISubmissionClient {
+    public class InMemorySubmissionClient : ISubmissionClient
+    {
         private static readonly Dictionary<string, object> _eventRepository = new Dictionary<string, object>();
         private static readonly Dictionary<string, object> _userDescriptionRepository = new Dictionary<string, object>();
 
-        public SubmissionResponse PostEvents(IEnumerable<Event> events, ExceptionlessConfiguration config, IJsonSerializer serializer) {
+        public SubmissionResponse PostEvents(IEnumerable<Event> events, ExceptionlessConfiguration config, IJsonSerializer serializer)
+        {
             foreach (Event e in events)
             {
                 string data = serializer.Serialize(e);
@@ -19,17 +22,19 @@ namespace Exceptionless.SampleConsole
                     : Guid.NewGuid().ToString("D");
                 _eventRepository[referenceId] = data;
             }
-            return new SubmissionResponse(200);
+            return new SubmissionResponse(HttpStatusCode.OK);
 
         }
 
-        public SubmissionResponse PostUserDescription(string referenceId, UserDescription description, ExceptionlessConfiguration config, IJsonSerializer serializer) {
+        public SubmissionResponse PostUserDescription(string referenceId, UserDescription description, ExceptionlessConfiguration config, IJsonSerializer serializer)
+        {
             string data = serializer.Serialize(description);
             _userDescriptionRepository[referenceId] = data;
-            return new SubmissionResponse(200);
+            return new SubmissionResponse(HttpStatusCode.OK);
         }
 
-        public SettingsResponse GetSettings(ExceptionlessConfiguration config, IJsonSerializer serializer) {
+        public SettingsResponse GetSettings(ExceptionlessConfiguration config, IJsonSerializer serializer)
+        {
             return new SettingsResponse(true);
         }
     }

--- a/Source/Shared/Configuration/ExceptionlessConfiguration.cs
+++ b/Source/Shared/Configuration/ExceptionlessConfiguration.cs
@@ -20,6 +20,7 @@ namespace Exceptionless {
         private string _serverUrl;
         private int _submissionBatchSize;
         private ValidationResult _validationResult;
+        private bool _persistQueue;
         private readonly List<string> _exclusions = new List<string>(); 
 
         public ExceptionlessConfiguration(IDependencyResolver resolver) {
@@ -27,6 +28,7 @@ namespace Exceptionless {
             UserAgent = DEFAULT_USER_AGENT;
             SubmissionBatchSize = DEFAULT_SUBMISSION_BATCH_SIZE;
             Enabled = true;
+            PersistQueue = true;
             EnableSSL = true;
             DefaultTags = new TagSet();
             DefaultData = new DataDictionary();
@@ -93,6 +95,11 @@ namespace Exceptionless {
         /// Whether the client is currently enabled or not. If it is disabled, submitted errors will be discarded and no data will be sent to the server.
         /// </summary>
         public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Whether or not queued items will be deleted after a finite number of retries or age
+        /// </summary>
+        public bool PersistQueue { get; set; }
 
         /// <summary>
         /// Whether or not the client should use SSL when communicating with the server.

--- a/Source/Shared/Extensions/FileStorageExtensions.cs
+++ b/Source/Shared/Extensions/FileStorageExtensions.cs
@@ -3,135 +3,310 @@ using System.Collections.Generic;
 using System.Linq;
 using Exceptionless.Models;
 using Exceptionless.Storage;
+using System.Text;
+using System.Text.RegularExpressions;
 
-namespace Exceptionless.Extensions {
-    public static class FileStorageExtensions {
+namespace Exceptionless.Extensions
+{
+    public static class FileStorageExtensions
+    {
         private static readonly object _lockObject = new object();
 
-        public static void Enqueue(this IObjectStorage storage, string queueName, Event ev) {
-            storage.SaveObject(String.Concat(queueName, "\\q\\", Guid.NewGuid().ToString("N"), ".0.json"), ev);
+        private static readonly char WildcardFilterChar = '*';
+        private static readonly char DirectorySeparatorChar = '\\';
+        private static readonly string JsonExtension = "json";
+        private static readonly string QueueDirectoryName = "q";
+        private static readonly string LockExtension = "x";
+
+        private static readonly TimeSpan DefaultQueueMaxAge = TimeSpan.FromDays(7);
+        private static readonly int DefaultMaxUploadAttempts = 10;
+
+        #region File storage helper classes
+        /// <summary>
+        /// File storage mechanism used to simplify attempt counting and renaming
+        /// </summary>
+        private class FileStorageName
+        {
+            public string Name { get; set; }
+            public int Attempts { get; set; }
+            public string Extension { get; set; }
+
+            private static ArgumentException AttemptsArgumentException(string name)
+            {
+                return new ArgumentException(String.Format("Path \"{0}\" must contain the number of attempts.", name));
+            }
+
+            public FileStorageName(string name)
+            {
+                string[] parts = name.Split('.');
+
+                try
+                {
+                    this.Name = parts[0];
+
+                    this.Attempts = int.Parse(parts[1]);
+
+                    this.Extension = parts[2];
+                }
+                catch (IndexOutOfRangeException)
+                {
+                    throw AttemptsArgumentException(name);
+                }
+                catch (FormatException)
+                {
+                    throw AttemptsArgumentException(name);
+                }
+            }
+
+            public override string ToString()
+            {
+                return string.Join(".", Name, Attempts, Extension);
+            }
         }
 
-        public static void CleanupQueueFiles(this IObjectStorage storage, string queueName, TimeSpan? maxAge = null, int? maxAttempts = 3) {
-            if (!maxAge.HasValue)
-                maxAge = TimeSpan.FromDays(1);
+        /// <summary>
+        /// File storage mechanism to simplify locking
+        /// </summary>
+        private class FileStorageLock
+        {
+            public string FullName { get; set; }
+            public bool Locked { get; set; }
 
-            if (!maxAttempts.HasValue || maxAttempts.Value <= 0)
-                maxAttempts = 3;
+            public FileStorageLock(string name)
+            {
+                string lockSuffix = '.' + LockExtension;
+                Locked = name.EndsWith(lockSuffix);
+                FullName = Locked ? name.Remove(name.Length - lockSuffix.Length) : name;
+            }
 
-            foreach (var file in storage.GetObjectList(queueName + "\\q\\*", 500).ToList()) {
-                if (file.Created < DateTime.Now.Subtract(maxAge.Value))
+            public override string ToString()
+            {
+                return Locked ? FullName + '.' + LockExtension : FullName;
+            }
+        }
+        #endregion File storage helper classes
+
+        /// <summary>
+        /// Gets the Queue Directory name of format: queueName\q
+        /// </summary>
+        /// <param name="queueName"></param>
+        /// <returns></returns>
+        private static string GetQueueDirectory(string queueName)
+        {
+            return queueName + DirectorySeparatorChar + QueueDirectoryName;
+        }
+
+        /// <summary>
+        /// Gets a new queued file name of format: 86998443a1294466bd12c1f9258cc394.json
+        /// </summary>
+        /// <returns></returns>
+        private static string GetNewQueuedItemName()
+        {
+            return Guid.NewGuid().ToString("N") + '.' + JsonExtension;
+        }
+
+        /// <summary>
+        /// Gets a filter for all items under the queue, regardless of extension: queueName\q\*
+        /// </summary>
+        /// <param name="queueName"></param>
+        /// <returns></returns>
+        private static string GetAllQueueItemsFilter(string queueName)
+        {
+            return GetQueueDirectory(queueName) + DirectorySeparatorChar + WildcardFilterChar;
+        }
+
+        /// <summary>
+        /// Gets a filter for all json (not including sub-extensions such as .json.x): queueName\q\*.json
+        /// </summary>
+        /// <param name="queueName"></param>
+        /// <returns></returns>
+        private static string GetJsonQueueItemsFilter(string queueName)
+        {
+            return GetQueueDirectory(queueName) + DirectorySeparatorChar + WildcardFilterChar + '.' + JsonExtension;
+        }
+
+        private static string GetAllLockedQueueItemsFilter(string queueName)
+        {
+            return GetQueueDirectory(queueName) + DirectorySeparatorChar + WildcardFilterChar + '.' + LockExtension;
+        }
+
+        /// <summary>
+        /// Saves an event as a json file in the designated storage queue
+        /// </summary>
+        /// <param name="storage"></param>
+        /// <param name="queueName"></param>
+        /// <param name="ev"></param>
+        public static void Enqueue(this IObjectStorage storage, string queueName, Event ev)
+        {
+            string queuedFilePath = GetQueueDirectory(queueName) + DirectorySeparatorChar + GetNewQueuedItemName();
+            storage.SaveObject(queuedFilePath, ev);
+        }
+
+        /// <summary>
+        /// Removes any files from the queue which are older than a maxAge or which have had an upload attempted more than maxAttempts times
+        /// </summary>
+        /// <param name="storage"></param>
+        /// <param name="queueName"></param>
+        /// <param name="maxAge"></param>
+        /// <param name="maxAttempts"></param>
+        public static void CleanupQueueFiles(this IObjectStorage storage, string queueName, TimeSpan? maxAge = null, int? maxAttempts = null)
+        {
+            maxAge = maxAge ?? DefaultQueueMaxAge;
+            maxAttempts = maxAttempts ?? DefaultMaxUploadAttempts;
+
+            if (maxAttempts.Value <= 0)
+                maxAttempts = DefaultMaxUploadAttempts;
+
+            foreach (var file in storage.GetObjectList(GetAllQueueItemsFilter(queueName)))
+            {
+                if (DateTime.Now.Subtract(file.Created) > maxAge)
                     storage.DeleteObject(file.Path);
-                if (GetAttempts(file) >= maxAttempts)
+                else if (GetAttempts(file) >= maxAttempts)
                     storage.DeleteObject(file.Path);
             }
         }
 
-        public static ICollection<ObjectInfo> GetQueueFiles(this IObjectStorage storage, string queueName, int? limit = null, DateTime? maxCreatedDate = null) {
-            return storage.GetObjectList(queueName + "\\q\\*.json", limit, maxCreatedDate).OrderByDescending(f => f.Created).ToList();
+        public static void CleanupAllQueueFiles(this IObjectStorage storage, string queueName)
+        {
+            storage.CleanupQueueFiles(queueName, TimeSpan.Zero, 0);
         }
 
-        public static bool IncrementAttempts(this IObjectStorage storage, ObjectInfo info) {
-            string[] parts = info.Path.Split('.');
-            if (parts.Length < 3)
-                throw new ArgumentException(String.Format("Path \"{0}\" must contain the number of attempts.", info.Path));
-
-            int version;
-            if (!Int32.TryParse(parts[1], out version))
-                throw new ArgumentException(String.Format("Path \"{0}\" must contain the number of attempts.", info.Path));
-
-            version++;
-            string newpath = String.Join(".", parts[0], version, parts[2]);
-            if (parts.Length == 4)
-                newpath += "." + parts[3];
-
-            string originalPath = info.Path;
-            info.Path = newpath;
-
-            return storage.RenameObject(originalPath, newpath);
+        /// <summary>
+        /// Gets a list of objects from the designated storage location, up to a specified limit and max age (maxCreatedDate)
+        /// </summary>
+        /// <param name="storage"></param>
+        /// <param name="queueName"></param>
+        /// <param name="limit"></param>
+        /// <param name="maxCreatedDate"></param>
+        /// <returns></returns>
+        public static ICollection<ObjectInfo> GetQueueFiles(this IObjectStorage storage, string queueName, int? limit = null, DateTime? maxCreatedDate = null)
+        {
+            string filter = GetJsonQueueItemsFilter(queueName);
+            return storage.GetObjectList(filter, limit, maxCreatedDate).OrderByDescending(f => f.Created).ToList();
         }
 
-        public static int GetAttempts(this ObjectInfo info) {
-            string[] parts = info.Path.Split('.');
-            if (parts.Length != 3)
+        /// <summary>
+        /// Edits the file extension of an item in the storage queue to indicate another attempt at upload
+        /// </summary>
+        /// <param name="storage"></param>
+        /// <param name="info"></param>
+        /// <returns></returns>
+        public static bool IncrementAttempts(this IObjectStorage storage, ObjectInfo info)
+        {
+            var fileInfo = new FileStorageName(info.Path);
+            fileInfo.Attempts++;
+
+            return storage.RenameObject(info.Path, fileInfo.ToString());
+        }
+
+        public static int GetAttempts(this ObjectInfo info)
+        {
+            try
+            {
+                var fileInfo = new FileStorageName(info.Path);
+                return fileInfo.Attempts;
+            }
+            catch (Exception)
+            {
                 return 0;
-
-            int attempts;
-            return !Int32.TryParse(parts[1], out attempts) ? 0 : attempts;
+            }
         }
 
-        public static bool LockFile(this IObjectStorage storage, ObjectInfo info) {
-            if (info.Path.EndsWith(".x"))
+        public static bool LockFile(this IObjectStorage storage, ObjectInfo info)
+        {
+            // Get lock info
+            var fileLockInfo = new FileStorageLock(info.Path);
+
+            // Lock acquisition failure if already locked
+            if (fileLockInfo.Locked)
                 return false;
 
-            string lockedPath = String.Concat(info.Path, ".x");
+            // Try to lock the file by renaming
+            fileLockInfo.Locked = true;
+            string lockedPath = fileLockInfo.ToString();
 
             bool success = storage.RenameObject(info.Path, lockedPath);
-            if (!success)
-                return false;
+            info.Path = success ? lockedPath : info.Path;
 
-            info.Path = lockedPath;
-            return true;
+            // Successful if the lock name was acquired
+            return success;
         }
 
-        public static bool ReleaseFile(this IObjectStorage storage, ObjectInfo info) {
-            if (!info.Path.EndsWith(".x"))
+        public static bool ReleaseFile(this IObjectStorage storage, ObjectInfo info)
+        {
+            // Get lock info
+            var fileLockInfo = new FileStorageLock(info.Path);
+
+            // Lock acquisition failure if already unlocked
+            if (!fileLockInfo.Locked)
                 return false;
 
-            string path = info.Path.Substring(0, info.Path.Length - 2);
+            // Try to unlock the file by renaming
+            fileLockInfo.Locked = false;
+            string unlockedPath = fileLockInfo.ToString();
 
-            bool success = storage.RenameObject(info.Path, path);
-            if (!success)
-                return false;
+            bool success = storage.RenameObject(info.Path, unlockedPath);
+            info.Path = success ? unlockedPath : info.Path;
 
-            info.Path = path;
-            return true;
+            // Successful if the lock name was acquired
+            return success;
         }
 
-        public static void ReleaseStaleLocks(this IObjectStorage storage, string queueName, TimeSpan? maxLockAge = null) {
+        public static void ReleaseStaleLocks(this IObjectStorage storage, string queueName, TimeSpan? maxLockAge = null)
+        {
             if (!maxLockAge.HasValue)
                 maxLockAge = TimeSpan.FromMinutes(60);
 
-            foreach (var file in storage.GetObjectList(queueName + "\\q\\*.x", 500).ToList().Where(f => f.Modified < DateTime.Now.Subtract(maxLockAge.Value)))
+            foreach (var file in storage.GetObjectList(GetAllLockedQueueItemsFilter(queueName)).Where(f => f.Modified < DateTime.Now.Subtract(maxLockAge.Value)))
                 storage.ReleaseFile(file);
         }
 
-        public static IList<Tuple<ObjectInfo, Event>> GetEventBatch(this IObjectStorage storage, string queueName, IJsonSerializer serializer, int batchSize = 50, DateTime? maxCreatedDate = null) {
+        public static IList<Tuple<ObjectInfo, Event>> GetEventBatch(this IObjectStorage storage, string queueName, IJsonSerializer serializer, int batchSize = 50, DateTime? maxCreatedDate = null)
+        {
             var events = new List<Tuple<ObjectInfo, Event>>();
 
-            lock (_lockObject) {
-                foreach (var file in storage.GetQueueFiles(queueName, batchSize * 5, maxCreatedDate)) {
+            lock (_lockObject)
+            {
+                foreach (var file in storage.GetQueueFiles(queueName, batchSize * 5, maxCreatedDate))
+                {
                     if (!storage.LockFile(file))
                         continue;
 
-                    try {
+                    try
+                    {
                         storage.IncrementAttempts(file);
-                    } catch {}
+                    }
+                    catch { }
 
-                    try {
+                    try
+                    {
                         var ev = storage.GetObject<Event>(file.Path);
                         events.Add(Tuple.Create(file, ev));
                         if (events.Count == batchSize)
                             break;
 
-                    } catch {}
+                    }
+                    catch { }
                 }
 
                 return events;
             }
         }
 
-        public static void DeleteFiles(this IObjectStorage storage, IEnumerable<ObjectInfo> files) {
+        public static void DeleteFiles(this IObjectStorage storage, IEnumerable<ObjectInfo> files)
+        {
             foreach (var file in files)
                 storage.DeleteObject(file.Path);
         }
 
-        public static void DeleteBatch(this IObjectStorage storage, IList<Tuple<ObjectInfo, Event>> batch) {
+        public static void DeleteBatch(this IObjectStorage storage, IList<Tuple<ObjectInfo, Event>> batch)
+        {
             foreach (var item in batch)
                 storage.DeleteObject(item.Item1.Path);
         }
 
-        public static void ReleaseBatch(this IObjectStorage storage, IList<Tuple<ObjectInfo, Event>> batch) {
+        public static void ReleaseBatch(this IObjectStorage storage, IList<Tuple<ObjectInfo, Event>> batch)
+        {
             foreach (var item in batch)
                 storage.ReleaseFile(item.Item1);
         }

--- a/Source/Shared/Submission/DefaultSubmissionClient.cs
+++ b/Source/Shared/Submission/DefaultSubmissionClient.cs
@@ -22,16 +22,16 @@ namespace Exceptionless.Submission {
                 if (ex != null)
                     response = (HttpWebResponse)ex.Response;
                 else
-                    return new SubmissionResponse(500, message: aex.GetMessage());
+                    return new SubmissionResponse(HttpStatusCode.InternalServerError, message: aex.GetMessage());
             } catch (Exception ex) {
-                return new SubmissionResponse(500, message: ex.Message);
+                return new SubmissionResponse(HttpStatusCode.InternalServerError, message: ex.Message);
             }
 
             int settingsVersion;
             if (Int32.TryParse(response.Headers[ExceptionlessHeaders.ConfigurationVersion], out settingsVersion))
                 SettingsManager.CheckVersion(settingsVersion, config);
 
-            return new SubmissionResponse((int)response.StatusCode, GetResponseMessage(response));
+            return new SubmissionResponse(response.StatusCode, GetResponseMessage(response));
         }
 
         public SubmissionResponse PostUserDescription(string referenceId, UserDescription description, ExceptionlessConfiguration config, IJsonSerializer serializer) {
@@ -46,16 +46,16 @@ namespace Exceptionless.Submission {
                 if (ex != null)
                     response = (HttpWebResponse)ex.Response;
                 else
-                    return new SubmissionResponse(500, message: aex.GetMessage());
+                    return new SubmissionResponse(HttpStatusCode.InternalServerError, message: aex.GetMessage());
             } catch (Exception ex) {
-                return new SubmissionResponse(500, message: ex.Message);
+                return new SubmissionResponse(HttpStatusCode.InternalServerError, message: ex.Message);
             }
 
             int settingsVersion;
             if (Int32.TryParse(response.Headers[ExceptionlessHeaders.ConfigurationVersion], out settingsVersion))
                 SettingsManager.CheckVersion(settingsVersion, config);
 
-            return new SubmissionResponse((int)response.StatusCode, GetResponseMessage(response));
+            return new SubmissionResponse(response.StatusCode, GetResponseMessage(response));
         }
 
         public SettingsResponse GetSettings(ExceptionlessConfiguration config, IJsonSerializer serializer) {

--- a/Source/Shared/Submission/SubmissionResponse.cs
+++ b/Source/Shared/Submission/SubmissionResponse.cs
@@ -3,11 +3,11 @@ using System.Net;
 
 namespace Exceptionless.Submission {
     public class SubmissionResponse {
-        public SubmissionResponse(int statusCode, string message = null) {
+        public SubmissionResponse(int statusCode, string message) {
             StatusCode = statusCode;
             Message = message;
 
-            Success = statusCode >= 200 && statusCode <= 299;
+            Success = statusCode >= 200 && statusCode < 300;
             BadRequest = (HttpStatusCode)statusCode == HttpStatusCode.BadRequest;
             ServiceUnavailable = (HttpStatusCode)statusCode == HttpStatusCode.ServiceUnavailable;
             PaymentRequired = (HttpStatusCode)statusCode == HttpStatusCode.PaymentRequired;
@@ -15,6 +15,12 @@ namespace Exceptionless.Submission {
             NotFound = (HttpStatusCode)statusCode == HttpStatusCode.NotFound;
             RequestEntityTooLarge = (HttpStatusCode)statusCode == HttpStatusCode.RequestEntityTooLarge;
         }
+
+        public SubmissionResponse(HttpStatusCode statusCode, string message) : this((int)statusCode, message) { }
+
+        public SubmissionResponse(int statusCode) : this(statusCode, null) { }
+
+        public SubmissionResponse(HttpStatusCode statusCode) : this((int)statusCode) { }
 
         public bool Success { get; private set; }
         public bool BadRequest { get; private set; }

--- a/Source/Tests/Utility/InMemorySubmissionClient.cs
+++ b/Source/Tests/Utility/InMemorySubmissionClient.cs
@@ -1,33 +1,41 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using Exceptionless;
 using Exceptionless.Models;
 using Exceptionless.Models.Data;
 using Exceptionless.Submission;
-using System.Net;
 
-namespace Exceptionless.SampleConsole
-{
-    public class InMemorySubmissionClient: ISubmissionClient {
-        private static readonly Dictionary<string, object> _eventRepository = new Dictionary<string, object>();
-        private static readonly Dictionary<string, object> _userDescriptionRepository = new Dictionary<string, object>();
+namespace Exceptionless.Tests.Utility {
+    public class InMemorySubmissionClient : ISubmissionClient {
+        public InMemorySubmissionClient() {
+            Events = new List<Event>();
+        }
+
+        public List<Event> Events { get; private set; } 
 
         public SubmissionResponse PostEvents(IEnumerable<Event> events, ExceptionlessConfiguration config, IJsonSerializer serializer) {
-            foreach (Event e in events)
-            {
-                string data = serializer.Serialize(e);
-                string referenceId = !string.IsNullOrWhiteSpace(e.ReferenceId)
-                    ? e.ReferenceId
-                    : Guid.NewGuid().ToString("D");
-                _eventRepository[referenceId] = data;
-            }
-            return new SubmissionResponse(HttpStatusCode.OK);
+            var data = events.ToList();
+            data.ForEach(e => {
+                if (e.Date == DateTimeOffset.MinValue)
+                    e.Date = DateTimeOffset.Now;
 
+                if (String.IsNullOrEmpty(e.Type))
+                    e.Type = Event.KnownTypes.Log;
+            });
+            Events.AddRange(data);
+
+            return new SubmissionResponse(202, "Accepted");
         }
 
         public SubmissionResponse PostUserDescription(string referenceId, UserDescription description, ExceptionlessConfiguration config, IJsonSerializer serializer) {
-            string data = serializer.Serialize(description);
-            _userDescriptionRepository[referenceId] = data;
-            return new SubmissionResponse(HttpStatusCode.OK);
+            var ev = Events.FirstOrDefault(e => e.ReferenceId == referenceId);
+            if (ev == null)
+                return new SubmissionResponse(404, "Not Found");
+
+            ev.Data[Event.KnownDataKeys.UserDescription] = description;
+
+            return new SubmissionResponse(200, "OK");
         }
 
         public SettingsResponse GetSettings(ExceptionlessConfiguration config, IJsonSerializer serializer) {

--- a/Source/Tests/Utility/InMemorySubmissionClient.cs
+++ b/Source/Tests/Utility/InMemorySubmissionClient.cs
@@ -1,41 +1,33 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using Exceptionless;
 using Exceptionless.Models;
 using Exceptionless.Models.Data;
 using Exceptionless.Submission;
+using System.Net;
 
-namespace Exceptionless.Tests.Utility {
-    public class InMemorySubmissionClient : ISubmissionClient {
-        public InMemorySubmissionClient() {
-            Events = new List<Event>();
-        }
-
-        public List<Event> Events { get; private set; } 
+namespace Exceptionless.SampleConsole
+{
+    public class InMemorySubmissionClient: ISubmissionClient {
+        private static readonly Dictionary<string, object> _eventRepository = new Dictionary<string, object>();
+        private static readonly Dictionary<string, object> _userDescriptionRepository = new Dictionary<string, object>();
 
         public SubmissionResponse PostEvents(IEnumerable<Event> events, ExceptionlessConfiguration config, IJsonSerializer serializer) {
-            var data = events.ToList();
-            data.ForEach(e => {
-                if (e.Date == DateTimeOffset.MinValue)
-                    e.Date = DateTimeOffset.Now;
+            foreach (Event e in events)
+            {
+                string data = serializer.Serialize(e);
+                string referenceId = !string.IsNullOrWhiteSpace(e.ReferenceId)
+                    ? e.ReferenceId
+                    : Guid.NewGuid().ToString("D");
+                _eventRepository[referenceId] = data;
+            }
+            return new SubmissionResponse(HttpStatusCode.OK);
 
-                if (String.IsNullOrEmpty(e.Type))
-                    e.Type = Event.KnownTypes.Log;
-            });
-            Events.AddRange(data);
-
-            return new SubmissionResponse(202, "Accepted");
         }
 
         public SubmissionResponse PostUserDescription(string referenceId, UserDescription description, ExceptionlessConfiguration config, IJsonSerializer serializer) {
-            var ev = Events.FirstOrDefault(e => e.ReferenceId == referenceId);
-            if (ev == null)
-                return new SubmissionResponse(404, "Not Found");
-
-            ev.Data[Event.KnownDataKeys.UserDescription] = description;
-
-            return new SubmissionResponse(200, "OK");
+            string data = serializer.Serialize(description);
+            _userDescriptionRepository[referenceId] = data;
+            return new SubmissionResponse(HttpStatusCode.OK);
         }
 
         public SettingsResponse GetSettings(ExceptionlessConfiguration config, IJsonSerializer serializer) {


### PR DESCRIPTION
Fixes:
- Added configuration setting to disable deletion of queue items
- Changed deletion settings of queue items for non-persistentQueue settings to 7 days and 10 attempts

Bug Fixes:
- Changed dependency resolution for IsolatedStorage to get around registration exception thrown

- Various readability and simplification improvements, especially around upload attempt counting and file locking in the queue