### PR TITLE
Fix CrashReportDialog styling

### DIFF
--- a/Source/Platforms/Wpf/Dialogs/CrashReportDialog.xaml
+++ b/Source/Platforms/Wpf/Dialogs/CrashReportDialog.xaml
@@ -1,64 +1,65 @@
 ﻿<Window x:Class="Exceptionless.Dialogs.CrashReportDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="[AppName] Error" Height="500" Width="425" 
+        Title="[AppName] Error" Height="525" Width="425" 
         WindowStyle="ToolWindow" WindowStartupLocation="CenterScreen" ResizeMode="NoResize"        
         Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
         FocusManager.FocusedElement="{Binding ElementName=DescriptionTextBox}"
         Icon="../Images/ErrorFeedback.png">
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="56" />
-            <RowDefinition Height="451*" />
+            <RowDefinition Height="60" />
+            <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <Grid Name="headerGrid" Background="White">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="363*" />
-                <ColumnDefinition Width="56" />
+                <ColumnDefinition Width="60" />
             </Grid.ColumnDefinitions>
-            <TextBlock Name="InformationHeaderLabel" TextWrapping="WrapWithOverflow" Margin="6" FontWeight="Bold">
+            <TextBlock Name="InformationHeaderLabel" TextWrapping="WrapWithOverflow" Margin="12" FontWeight="Bold">
                 [AppName] has encountered a problem and needs to close.  We are sorry for the inconvenience.
             </TextBlock>
-            <Image Name="errorImage" Grid.Column="2" Stretch="Fill" 
+            <Image Name="errorImage" Grid.Column="2"  
                    Source="../Images/ErrorFeedback.png" 
                    HorizontalAlignment="Center" VerticalAlignment="Center" Width="48" Height="48" />
         </Grid>
 
-        <StackPanel Grid.Row="1" Name="mainStackPanel">
-            <TextBlock Name="errorMessage" TextWrapping="WrapWithOverflow" Margin="6">            
+        <StackPanel Grid.Row="1" Name="mainStackPanel" Margin="12">
+            <TextBlock Name="errorMessage" TextWrapping="WrapWithOverflow">            
                 If you were in the middle of something, the information you were working on might be lost.<LineBreak/>
                 <LineBreak/>
                 We have created an error report that you can send to us.  We will treat this error as confidential and anonymous.<LineBreak/>
                 <LineBreak/>
-                To help us diagnose the cause of this error and improve the software, please enter your email address, describe what you were doing when this error occurred, and send this error to us.<LineBreak/>
+                To help us diagnose the cause of this error and improve the software, please enter your email address, describe what you were doing when this error occurred, and send this error to us.
             </TextBlock>
 
-            <Label Name="emailAddressLabel" Margin="6,0" 
+            <Label Name="emailAddressLabel"
                    HorizontalAlignment="Left" 
                    VerticalAlignment="Top" 
+                   Margin="0,6,0,0"
                    Content="Your _email address (optional):" />
             <TextBox Name="EmailAddressTextBox" 
-                     HorizontalAlignment="Left" 
+                     HorizontalAlignment="Stretch" 
                      VerticalAlignment="Top" 
-                     Width="358" 
-                     Margin="6,0" />
+                      
+                     />
 
             <Label Name="descriptionLabel" 
                    HorizontalAlignment="Left" 
-                   VerticalAlignment="Top" 
-                   Margin="6,0" 
+                   VerticalAlignment="Top"   
+                   Margin="0,6,0,0"
                    Content="_Describe what you were doing when the error occurred (optional): " />
             <TextBox Name="DescriptionTextBox" 
-                     Height="120" Width="358" 
-                     HorizontalAlignment="Left" 
+                     Height="120"
+                     HorizontalAlignment="Stretch" 
                      VerticalAlignment="Top" 
                      TextWrapping="Wrap" 
                      VerticalScrollBarVisibility="Auto" 
                      HorizontalScrollBarVisibility ="Visible" 
                      SpellCheck.IsEnabled="True"
-                     Margin="6,0"  />
+                     />
 
             <!--<TextBlock Name="detailTextBlock" 
                        HorizontalAlignment="Left" 
@@ -71,16 +72,18 @@
         <DockPanel Grid.Row="2" Margin="6">
             <Button Name="CancelButton"
                     DockPanel.Dock="Right"
-                    Height="23" Width="75" 
+                    Height="23" MinWidth="75" 
                     HorizontalAlignment="Right" 
                     Margin="4" 
+                    Padding="8,0,8,0"
                     IsCancel="True" 
                     Content="_Cancel" />
             <Button Name="SubmitReportButton" 
                     DockPanel.Dock="Right"
-                    Height="23" Width="100" 
+                    Height="23" MinWidth="100"
                     HorizontalAlignment="Right" 
                     Margin="4" 
+                    Padding="8,0,8,0"
                     IsDefault="True" 
                     Content="_Submit Report" 
                     Click="OnSubmitReportButtonClick" />

--- a/Source/Platforms/Wpf/ExceptionlessClientExtensions.cs
+++ b/Source/Platforms/Wpf/ExceptionlessClientExtensions.cs
@@ -23,7 +23,7 @@ namespace Exceptionless.Wpf.Extensions {
                 System.Windows.Forms.Application.ThreadException -= _onApplicationThreadException;
                 System.Windows.Forms.Application.ThreadException += _onApplicationThreadException;
             } catch (Exception ex) {
-                client.Configuration.Resolver.GetLog().Error(typeof(ExceptionlessClientExtensions), ex, "An error occurred while wiring up to the unobserved task exception event.");
+                client.Configuration.Resolver.GetLog().Error(typeof(ExceptionlessClientExtensions), ex, "An error occurred while wiring up to the application thread exception event.");
             }
         }
 
@@ -55,7 +55,7 @@ namespace Exceptionless.Wpf.Extensions {
                 System.Windows.Application.Current.DispatcherUnhandledException -= _onApplicationDispatcherUnhandledException;
                 System.Windows.Application.Current.DispatcherUnhandledException += _onApplicationDispatcherUnhandledException;
             } catch (Exception ex) {
-                client.Configuration.Resolver.GetLog().Error(typeof(ExceptionlessClientExtensions), ex, "An error occurred while wiring up to the unobserved task exception event.");
+                client.Configuration.Resolver.GetLog().Error(typeof(ExceptionlessClientExtensions), ex, "An error occurred while wiring up to the application dispatcher exception event.");
             }
         }
 


### PR DESCRIPTION
@niemyjski here is a pull request for my first problem described in #60.

Buttons now use padding instead of hardcoded width. I have also added margins to achieve better spacing between controls. 

I have also included a minor fix to log messages.

#### Screenshot from sample application (Windows 10):

![image](https://cloud.githubusercontent.com/assets/1139118/10479951/899638b4-7267-11e5-8521-0469c48b6624.png)

#### Screenshot with material design theme (Windows 10):

![image](https://cloud.githubusercontent.com/assets/1139118/10479981/be38c8fc-7267-11e5-8b97-400b5dc13c2a.png)

