### PR TITLE
Pass same ExceptionlessClient to WebApi exception filter

### DIFF
--- a/Source/Platforms/WebApi/ExceptionlessHandleErrorAttribute.cs
+++ b/Source/Platforms/WebApi/ExceptionlessHandleErrorAttribute.cs
@@ -8,10 +8,20 @@ using TaskExtensions = Exceptionless.Threading.Tasks.TaskExtensions;
 
 namespace Exceptionless.WebApi {
     public class ExceptionlessHandleErrorAttribute : IExceptionFilter {
+        private readonly ExceptionlessClient _client;
+
         public bool HasWrappedFilter { get { return WrappedFilter != null; } }
 
         public IExceptionFilter WrappedFilter { get; set; }
         public bool AllowMultiple { get { return HasWrappedFilter && WrappedFilter.AllowMultiple; } }
+
+        public ExceptionlessHandleErrorAttribute() : this(ExceptionlessClient.Default) {
+            
+        }
+
+        public ExceptionlessHandleErrorAttribute(ExceptionlessClient client) {
+            _client = client;
+        }
 
         public virtual void OnHttpException(HttpActionExecutedContext actionExecutedContext, CancellationToken cancellationToken) {
             if (HasWrappedFilter)
@@ -22,7 +32,7 @@ namespace Exceptionless.WebApi {
             contextData.SetSubmissionMethod("ExceptionHttpFilter");
             contextData.Add("HttpActionContext", actionExecutedContext.ActionContext);
 
-            actionExecutedContext.Exception.ToExceptionless(contextData).Submit();
+            actionExecutedContext.Exception.ToExceptionless(contextData, client: _client).Submit();
         }
 
         public Task ExecuteExceptionFilterAsync(HttpActionExecutedContext actionExecutedContext, CancellationToken cancellationToken) {

--- a/Source/Platforms/WebApi/ExceptionlessWebApiExtensions.cs
+++ b/Source/Platforms/WebApi/ExceptionlessWebApiExtensions.cs
@@ -25,7 +25,7 @@ namespace Exceptionless {
             config.Services.Add(typeof(IExceptionLogger), new ExceptionlessExceptionLogger());
 #endif
 
-            ReplaceHttpErrorHandler(config);
+            ReplaceHttpErrorHandler(config, client);
         }
 
         /// <summary>
@@ -37,9 +37,9 @@ namespace Exceptionless {
             client.Configuration.RemovePlugin<ExceptionlessWebApiPlugin>();
         }
 
-        private static void ReplaceHttpErrorHandler(HttpConfiguration config) {
+        private static void ReplaceHttpErrorHandler(HttpConfiguration config, ExceptionlessClient exceptionlessClient) {
             FilterInfo filter = config.Filters.FirstOrDefault(f => f.Instance is IExceptionFilter);
-            var handler = new ExceptionlessHandleErrorAttribute();
+            var handler = new ExceptionlessHandleErrorAttribute(exceptionlessClient);
 
             if (filter != null) {
                 if (filter.Instance is ExceptionlessHandleErrorAttribute)


### PR DESCRIPTION
This ensures that exceptions handled by the WebApi `ExceptionlessHandleErrorAttribute` are processed by the same `ExceptionlessClient` that was passed to `RegisterWebApi`. Prior to this, `ExceptionlessHandleErrorAttribute` would always use `ExceptionlessClient.Default`, regardless of what was passed to `RegisterWebApi`.