### PR TITLE
NuGet install.ps1 scripts - create a <configSections> node if it doesn't exist

### DIFF
--- a/Source/Shared/NuGet/tools/exceptionless.psm1
+++ b/Source/Shared/NuGet/tools/exceptionless.psm1
@@ -36,6 +36,15 @@ function update_config($configPath, $platform) {
 	$shouldSave = $false
 
 	if ($configXml -ne $null) {
+		
+		$configSections = $configXml.SelectSingleNode("configuration/configSections")
+		if ($configSections -eq $null)
+		{
+			$configuration = $configXml.SelectSingleNode("configuration")
+			$configSections = $configXml.CreateElement('configSections')	
+			$configuration.AppendChild($configSections)
+		}
+		
 		$configSection = $configXml.SelectSingleNode("configuration/configSections/section[@name='exceptionless']")
 		if ($configSection -eq $null) {
 			$parentNode = $configXml.SelectSingleNode("configuration/configSections")


### PR DESCRIPTION
I haven't been able to test the changes outside of running them in a Powershell console. This change will append `<configSections>` to the bottom of the web.config file if it doesn't exists, which isn't ideal but the $configXml object doesn't give you much choice.