### PR TITLE
2x tweaks to the AppVeyor deployment script.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,10 +3,14 @@ os: Visual Studio 2015
 clone_depth: 2
 configuration: Release
 
+pull_requests:
+  do_not_increment_build_number: true
+  
 #environment:
 #  VERSION_SUFFIX: -preview
 
 init:
+  - ps: iex ((new-object net.webclient).DownloadString('https://gist.githubusercontent.com/PureKrome/0f79e25693d574807939/raw/8cf3160c9516ef1f4effc825c0a44acc918a0b5a/appveyor-build-info.ps'))
   - git config --global core.autocrlf true
   - ps: $env:GIT_HASH=$env:APPVEYOR_REPO_COMMIT.Substring(0, 10)
   - ps: If ("$env:APPVEYOR_REPO_TAG" -ne "true") { $env:VERSION_SUFFIX="-pre" }


### PR DESCRIPTION
- Add some more AppVeyor information to the AV log output.
- For PR's, the build number doesn't increment. This helps (big time) when pushing up stuff up to nuget and having the PR not incremement build numbers.

![](http://i.giphy.com/8zFBWmVItnZ0Q.gif)