### PR TITLE
Fixed a bug where exceptions converted into 404's were not being run through exclusions

### DIFF
--- a/src/Exceptionless/Extensions/EventExtensions.cs
+++ b/src/Exceptionless/Extensions/EventExtensions.cs
@@ -68,7 +68,7 @@ namespace Exceptionless {
         public static bool IsFeatureUsage(this Event ev) {
             return ev.Type == Event.KnownTypes.FeatureUsage;
         }
-        
+
         /// <summary>
         /// Returns true if the event type is session start.
         /// </summary>
@@ -85,7 +85,7 @@ namespace Exceptionless {
 
             ev.Data[Event.KnownDataKeys.RequestInfo] = request;
         }
-        
+
         /// <summary>
         /// Sets the version that the event happened on.
         /// </summary>
@@ -97,14 +97,14 @@ namespace Exceptionless {
 
             ev.Data[Event.KnownDataKeys.Version] = version.Trim();
         }
-        
+
         /// <summary>
         /// Gets the user info object from extended data.
         /// </summary>
         public static UserInfo GetUserIdentity(this Event ev, IJsonSerializer serializer = null) {
             return ev.GetDataValue<UserInfo>(Event.KnownDataKeys.UserInfo, serializer);
         }
-        
+
         /// <summary>
         /// Sets the user's identity (ie. email address, username, user id) that the event happened to.
         /// </summary>
@@ -187,7 +187,7 @@ namespace Exceptionless {
             else
                 throw new ArgumentException("Must be either lat,lon or an IP address.", "coordinates");
         }
-        
+
         /// <summary>
         /// Sets the event geo coordinates.
         /// </summary>
@@ -312,7 +312,7 @@ namespace Exceptionless {
         public static void SetManualStackingKey(this Event ev, string title, string manualStackingKey) {
             if (String.IsNullOrWhiteSpace(title) || String.IsNullOrWhiteSpace(manualStackingKey))
                 return;
-            
+
             ev.Data[Event.KnownDataKeys.ManualStackingInfo] = new ManualStackingInfo(title, new Dictionary<string, string> { { "ManualStackingKey", manualStackingKey } });
         }
 

--- a/src/Exceptionless/Extensions/ExceptionlessClientExtensions.cs
+++ b/src/Exceptionless/Extensions/ExceptionlessClientExtensions.cs
@@ -11,7 +11,7 @@ using Exceptionless.Submission;
 namespace Exceptionless {
     public static class ExceptionlessClientExtensions {
         /// <summary>
-        /// Reads configuration settings, configures various plugins and wires up to platform specific exception handlers. 
+        /// Reads configuration settings, configures various plugins and wires up to platform specific exception handlers.
         /// </summary>
         /// <param name="client">The ExceptionlessClient.</param>
         /// <param name="apiKey">The API key that will be used when sending events to the server.</param>
@@ -21,7 +21,7 @@ namespace Exceptionless {
 
             if (!String.IsNullOrEmpty(apiKey))
                 client.Configuration.ApiKey = apiKey;
-            
+
             client.Configuration.ReadAllConfig();
 
 #if !PORTABLE && !NETSTANDARD1_2
@@ -38,7 +38,7 @@ namespace Exceptionless {
             client.RegisterOnProcessExitHandler();
 #endif
             client.RegisterTaskSchedulerUnobservedTaskExceptionHandler();
-            
+
             if (client.Configuration.SessionsEnabled)
                 client.SubmitSessionStart();
         }
@@ -56,12 +56,12 @@ namespace Exceptionless {
             client.UnregisterOnProcessExitHandler();
 #endif
             client.UnregisterTaskSchedulerUnobservedTaskExceptionHandler();
-            
+
             client.ProcessQueue();
             if (client.Configuration.SessionsEnabled)
                 client.SubmitSessionEnd();
         }
-        
+
 #region Submission Extensions
 
         /// <summary>
@@ -369,7 +369,7 @@ namespace Exceptionless.Extensions {
 
                     // process queue immediately since the app is about to exit.
                     client.ProcessQueue();
-        
+
                     if (client.Configuration.SessionsEnabled)
                         client.SubmitSessionEnd();
                 };
@@ -389,7 +389,7 @@ namespace Exceptionless.Extensions {
 
             if (_onAppDomainUnhandledException == null)
                 return;
-            
+
             AppDomain.CurrentDomain.UnhandledException -= _onAppDomainUnhandledException;
             _onAppDomainUnhandledException = null;
         }

--- a/src/Platforms/Exceptionless.AspNetCore/ExceptionlessExtensions.cs
+++ b/src/Platforms/Exceptionless.AspNetCore/ExceptionlessExtensions.cs
@@ -21,7 +21,7 @@ namespace Exceptionless {
             client.Configuration.AddPlugin<ExceptionlessAspNetCorePlugin>();
             client.Configuration.AddPlugin<IgnoreUserAgentPlugin>();
             //client.Configuration.Resolver.Register<ILastReferenceIdManager, WebLastReferenceIdManager>();
-            
+
             var diagnosticListener = app.ApplicationServices.GetRequiredService<DiagnosticListener>();
             diagnosticListener?.SubscribeWithAdapter(new ExceptionlessDiagnosticListener(client));
 

--- a/src/Platforms/Exceptionless.Mvc/ExceptionlessModule.cs
+++ b/src/Platforms/Exceptionless.Mvc/ExceptionlessModule.cs
@@ -17,7 +17,7 @@ namespace Exceptionless.Mvc {
             ExceptionlessClient.Default.Configuration.AddPlugin<ExceptionlessWebPlugin>();
             ExceptionlessClient.Default.Configuration.AddPlugin<IgnoreUserAgentPlugin>();
             ExceptionlessClient.Default.Configuration.Resolver.Register<ILastReferenceIdManager, WebLastReferenceIdManager>();
-            
+
             _app = app;
 
             if (!GlobalFilters.Filters.Any(f => f.Instance is ExceptionlessSendErrorsAttribute))
@@ -26,7 +26,7 @@ namespace Exceptionless.Mvc {
 
         public void Dispose() {
             ExceptionlessClient.Default.Shutdown();
-            ExceptionlessClient.Default.RegisterHttpApplicationErrorHandler(_app);
+            ExceptionlessClient.Default.UnregisterHttpApplicationErrorHandler(_app);
         }
     }
 }

--- a/src/Platforms/Exceptionless.Web/ExceptionlessClientExtensions.cs
+++ b/src/Platforms/Exceptionless.Web/ExceptionlessClientExtensions.cs
@@ -37,7 +37,7 @@ namespace Exceptionless.Web.Extensions {
             }
         }
 
-        public static void UnregisterHttpApplicationErrorExceptionHandler(this ExceptionlessClient client, HttpApplication app) {
+        public static void UnregisterHttpApplicationErrorHandler(this ExceptionlessClient client, HttpApplication app) {
             if (client == null)
                 throw new ArgumentNullException(nameof(client));
 

--- a/src/Platforms/Exceptionless.Web/ExceptionlessModule.cs
+++ b/src/Platforms/Exceptionless.Web/ExceptionlessModule.cs
@@ -14,13 +14,13 @@ namespace Exceptionless.Web {
             ExceptionlessClient.Default.Configuration.AddPlugin<ExceptionlessWebPlugin>();
             ExceptionlessClient.Default.Configuration.AddPlugin<IgnoreUserAgentPlugin>();
             ExceptionlessClient.Default.Configuration.Resolver.Register<ILastReferenceIdManager, WebLastReferenceIdManager>();
-            
+
             _app = app;
         }
 
         public void Dispose() {
             ExceptionlessClient.Default.Shutdown();
-            ExceptionlessClient.Default.UnregisterHttpApplicationErrorExceptionHandler(_app);
+            ExceptionlessClient.Default.UnregisterHttpApplicationErrorHandler(_app);
         }
     }
 }

--- a/src/Platforms/Exceptionless.WebApi/ExceptionlessWebApiPlugin.cs
+++ b/src/Platforms/Exceptionless.WebApi/ExceptionlessWebApiPlugin.cs
@@ -37,13 +37,17 @@ namespace Exceptionless.WebApi {
             if (ri == null)
                 return;
 
-            var error = context.Event.GetError(serializer);
-            if (error != null && error.Code == "404") {
-                context.Event.Type = Event.KnownTypes.NotFound;
-                context.Event.Source = ri.GetFullPath(includeHttpMethod: true, includeHost: false, includeQueryString: false);
-            }
-
             context.Event.AddRequestInfo(ri);
+            var error = context.Event.GetError(serializer);
+            if (error == null || error.Code != "404")
+                return;
+
+            context.Event.Type = Event.KnownTypes.NotFound;
+            context.Event.Source = ri.GetFullPath(includeHttpMethod: true, includeHost: false, includeQueryString: false);
+            if (!context.Client.Configuration.Settings.GetTypeAndSourceEnabled(context.Event.Type, context.Event.Source)) {
+                context.Log.Info(String.Format("Cancelling event from excluded type: {0} and source: {1}", context.Event.Type, context.Event.Source));
+                context.Cancel = true;
+            }
         }
 
         private static void AddUser(EventPluginContext context, HttpActionContext actionContext, IJsonSerializer serializer) {


### PR DESCRIPTION
I went back and forth on whether I should add a new plugin just
to check this at the end of the pipeline but decided against adding
extra work at the cost of being non dry...

I also considered looking at all integration points to where we log
exceptions and do the 404 logic there, but that would also add a bunch
of duplicated logic (for wrapping http context, getting request info for
the source etc...) Also you might still want to log the exception object
that created the 404...