### PR TITLE
FolderObjectStorage will only search in all directories if the search pattern starts with a wildcard

### DIFF
--- a/src/Exceptionless.Tests/Plugins/PluginTests.cs
+++ b/src/Exceptionless.Tests/Plugins/PluginTests.cs
@@ -226,6 +226,8 @@ namespace Exceptionless.Tests.Plugins {
         [InlineData("@@error:Exception", false)]
         [InlineData("@@error:System.Exception", true)]
         [InlineData("@@error:*Exception", true)]
+        [InlineData("@@error:*Exception*", true)]
+        [InlineData("@@error:*exception", true)]
         [InlineData("@@error:*", true)]
         public void EventExclusionPlugin_ExceptionType(string settingKey, bool cancelled) {
             var client = CreateClient();

--- a/src/Exceptionless/Storage/FolderObjectStorage.cs
+++ b/src/Exceptionless/Storage/FolderObjectStorage.cs
@@ -121,7 +121,8 @@ namespace Exceptionless.Storage {
 
             var list = new List<ObjectInfo>();
 
-            foreach (var path in Directory.GetFiles(Folder, searchPattern, SearchOption.AllDirectories)) {
+            var searchOption = searchPattern.StartsWith("*") ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
+            foreach (var path in Directory.GetFiles(Folder, searchPattern, searchOption)) {
                 var info = new System.IO.FileInfo(path);
                 if (!info.Exists || info.CreationTime > maxCreatedDate)
                     continue;


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=42715