### PR TITLE
use the latest version of BenchmarkDotNet and disable shadow copy to …

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="appveyor-bdn" value="https://ci.appveyor.com/nuget/benchmarkdotnet" />    
+  </packageSources>
+</configuration>

--- a/test/Exceptionless.Tests/Exceptionless.Tests.csproj
+++ b/test/Exceptionless.Tests/Exceptionless.Tests.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.3" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.3.91" />
     <PackageReference Include="Moq" Version="4.7.1" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.extensibility.core" Version="2.2.0" />
@@ -34,5 +34,11 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/test/Exceptionless.Tests/Plugins/PluginTests.cs
+++ b/test/Exceptionless.Tests/Plugins/PluginTests.cs
@@ -880,7 +880,7 @@ namespace Exceptionless.Tests.Plugins {
             }
         }
 
-        [Fact (Skip = "Skip until https://github.com/dotnet/BenchmarkDotNet/issues/395 is fixed")]
+        [Fact]
         public void RunBenchmark() {
             var summary = BenchmarkRunner.Run<DeduplicationBenchmarks>();
 

--- a/test/Exceptionless.Tests/xunit.runner.json
+++ b/test/Exceptionless.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "shadowCopy": false
+}


### PR DESCRIPTION
Hi!

I have fixed the [bug](https://github.com/dotnet/BenchmarkDotNet/issues/395) that was blocking you from using BenchmarkDotNet.

It required following changes:

1. Use our CI NuGet feed to get the latest version
2. Disable shadow copy for the xunit


You can test it by running: `dotnet test -f net46 -c Release --filter "FullyQualifiedName=Exceptionless.Tests.Plugins.PluginTests.RunBenchmark"` from `Exceptionless.Net\test\Exceptionless.Tests` folder