### PR TITLE
Fixes ProcessQueue method so it blocks until queue has been processed

### DIFF
--- a/src/Exceptionless/Queue/DefaultEventQueue.cs
+++ b/src/Exceptionless/Queue/DefaultEventQueue.cs
@@ -22,7 +22,7 @@ namespace Exceptionless.Queue {
         private DateTime? _suspendProcessingUntil;
         private DateTime? _discardQueuedItemsUntil;
 
-        public DefaultEventQueue(ExceptionlessConfiguration config, IExceptionlessLog log, ISubmissionClient client, IObjectStorage objectStorage, IJsonSerializer serializer) : this(config, log, client, objectStorage, serializer, null, null) { }
+        public DefaultEventQueue(ExceptionlessConfiguration config, IExceptionlessLog log, ISubmissionClient client, IObjectStorage objectStorage, IJsonSerializer serializer): this(config, log, client, objectStorage, serializer, null, null) {}
 
         public DefaultEventQueue(ExceptionlessConfiguration config, IExceptionlessLog log, ISubmissionClient client, IObjectStorage objectStorage, IJsonSerializer serializer, TimeSpan? processQueueInterval, TimeSpan? queueStartDelay) {
             _log = log;
@@ -86,52 +86,43 @@ namespace Exceptionless.Queue {
                         var response = _client.PostEvents(events, _config, _serializer);
                         if (response.Success) {
                             _log.FormattedInfo(typeof(DefaultEventQueue), "Sent {0} events to \"{1}\".", batch.Count, _config.ServerUrl);
-                        }
-                        else if (response.ServiceUnavailable) {
+                        } else if (response.ServiceUnavailable) {
                             // You are currently over your rate limit or the servers are under stress.
                             _log.Error(typeof(DefaultEventQueue), "Server returned service unavailable.");
                             SuspendProcessing();
                             deleteBatch = false;
-                        }
-                        else if (response.PaymentRequired) {
+                        } else if (response.PaymentRequired) {
                             // If the organization over the rate limit then discard the event.
                             _log.Warn(typeof(DefaultEventQueue), "Too many events have been submitted, please upgrade your plan.");
                             SuspendProcessing(discardFutureQueuedItems: true, clearQueue: true);
-                        }
-                        else if (response.UnableToAuthenticate) {
+                        } else if (response.UnableToAuthenticate) {
                             // The api key was suspended or could not be authorized.
                             _log.Error(typeof(DefaultEventQueue), "Unable to authenticate, please check your configuration. The event will not be submitted.");
                             SuspendProcessing(TimeSpan.FromMinutes(15));
-                        }
-                        else if (response.NotFound || response.BadRequest) {
+                        } else if (response.NotFound || response.BadRequest) {
                             // The service end point could not be found.
                             _log.FormattedError(typeof(DefaultEventQueue), "Error while trying to submit data: {0}", response.Message);
                             SuspendProcessing(TimeSpan.FromHours(4));
-                        }
-                        else if (response.RequestEntityTooLarge) {
+                        } else if (response.RequestEntityTooLarge) {
                             if (batchSize > 1) {
                                 _log.Error(typeof(DefaultEventQueue), "Event submission discarded for being too large. The event will be retried with a smaller batch size.");
                                 batchSize = Math.Max(1, (int)Math.Round(batchSize / 1.5d, 0));
                                 deleteBatch = false;
-                            }
-                            else {
+                            } else {
                                 _log.Error(typeof(DefaultEventQueue), "Event submission discarded for being too large. The event will not be submitted.");
                             }
-                        }
-                        else if (!response.Success) {
+                        } else if (!response.Success) {
                             _log.Error(typeof(DefaultEventQueue), String.Concat("An error occurred while submitting events: ", response.Message));
                             SuspendProcessing();
                             deleteBatch = false;
                         }
 
                         OnEventsPosted(new EventsPostedEventArgs { Events = events, Response = response });
-                    }
-                    catch (AggregateException ex) {
+                    } catch (AggregateException ex) {
                         _log.Error(typeof(DefaultEventQueue), ex, String.Concat("An error occurred while submitting events: ", ex.Flatten().Message));
                         SuspendProcessing();
                         deleteBatch = false;
-                    }
-                    catch (Exception ex) {
+                    } catch (Exception ex) {
                         _log.Error(typeof(DefaultEventQueue), ex, String.Concat("An error occurred while submitting events: ", ex.Message));
                         SuspendProcessing();
                         deleteBatch = false;
@@ -147,12 +138,10 @@ namespace Exceptionless.Queue {
 
                     batch = _storage.GetEventBatch(_config.GetQueueName(), _serializer, batchSize, maxCreatedDate);
                 }
-            }
-            catch (Exception ex) {
+            } catch (Exception ex) {
                 _log.Error(typeof(DefaultEventQueue), ex, String.Concat("An error occurred while processing the queue: ", ex.Message));
                 SuspendProcessing();
-            }
-            finally {
+            } finally {
                 tcs.SetResult(true);
                 lock (sync) {
                     _processingQueueTask = null;
@@ -188,8 +177,7 @@ namespace Exceptionless.Queue {
 #pragma warning disable 4014
                 _storage.CleanupQueueFiles(_config.GetQueueName(), TimeSpan.Zero);
 #pragma warning restore 4014
-            }
-            catch (Exception) { }
+            } catch (Exception) { }
         }
 
         public event EventHandler<EventsPostedEventArgs> EventsPosted;
@@ -198,8 +186,7 @@ namespace Exceptionless.Queue {
             try {
                 if (EventsPosted != null)
                     EventsPosted.Invoke(this, e);
-            }
-            catch (Exception ex) {
+            } catch (Exception ex) {
                 _log.Error(typeof(DefaultEventQueue), ex, "Error while calling OnEventsPosted event handlers.");
             }
         }

--- a/src/Exceptionless/Queue/DefaultEventQueue.cs
+++ b/src/Exceptionless/Queue/DefaultEventQueue.cs
@@ -17,7 +17,7 @@ namespace Exceptionless.Queue {
         private readonly IJsonSerializer _serializer;
         private Timer _queueTimer;
         private Task _processingQueueTask;
-        private readonly object sync = new object();
+        private readonly object _sync = new object();
         private readonly TimeSpan _processQueueInterval = TimeSpan.FromSeconds(10);
         private DateTime? _suspendProcessingUntil;
         private DateTime? _discardQueuedItemsUntil;
@@ -59,11 +59,10 @@ namespace Exceptionless.Queue {
             }
 
             TaskCompletionSource<bool> tcs;
-            lock (sync) {
+            lock (_sync) {
                 if (_processingQueueTask != null) {
                     return _processingQueueTask;
-                }
-                else {
+                } else {
                     tcs = new TaskCompletionSource<bool>();
                     _processingQueueTask = tcs.Task;
                 }
@@ -143,7 +142,7 @@ namespace Exceptionless.Queue {
                 SuspendProcessing();
             } finally {
                 tcs.SetResult(true);
-                lock (sync) {
+                lock (_sync) {
                     _processingQueueTask = null;
                     resultTask = tcs.Task;
                 }

--- a/src/Exceptionless/Queue/DefaultEventQueue.cs
+++ b/src/Exceptionless/Queue/DefaultEventQueue.cs
@@ -46,7 +46,7 @@ namespace Exceptionless.Queue {
         }
 
         public Task ProcessAsync() {
-            return Task.Run(() => Process());
+            return Task.Run(Process);
         }
 
         public Task Process() {

--- a/src/Exceptionless/Queue/DefaultEventQueue.cs
+++ b/src/Exceptionless/Queue/DefaultEventQueue.cs
@@ -46,10 +46,7 @@ namespace Exceptionless.Queue {
         }
 
         public Task ProcessAsync() {
-            return Task.Factory.StartNew(
-                () => {
-                    Process().ConfigureAwait(false).GetAwaiter().GetResult();
-                });
+            return Task.Run(() => Process());
         }
 
         public Task Process() {


### PR DESCRIPTION
ExceptionlessClient.Default.ProcessQueue() wouldn't block when Processing is under way.
The fix changes DefaultEventQueue.Process() by introducing an instance of Task while Process() is running (instead of **bool _processingQueue**).
If Process() method is running it'd return its Task when further calls are made. So the caller can await its completition.
Also removes unnecessary call to processingQueue within OnProcessQueue method.
This PR fixes issue #147.