### PR TITLE
Fix issue that the logging content cannot be recognized in Chinese environment.

### DIFF
--- a/src/Exceptionless/Logging/FileExceptionlessLog.cs
+++ b/src/Exceptionless/Logging/FileExceptionlessLog.cs
@@ -40,10 +40,10 @@ namespace Exceptionless.Logging {
         protected virtual WrappedDisposable<StreamWriter> GetWriter(bool append = false) {
 #if NETSTANDARD
             return new WrappedDisposable<StreamWriter>(new StreamWriter(
-                new FileStream(FilePath, append ? FileMode.Append : FileMode.Truncate, FileAccess.Write, FileShare.ReadWrite), Encoding.ASCII)
+                new FileStream(FilePath, append ? FileMode.Append : FileMode.Truncate, FileAccess.Write, FileShare.ReadWrite), Encoding.UTF8)
             );
 #else
-            return new WrappedDisposable<StreamWriter>(new StreamWriter(FilePath, append, Encoding.ASCII));
+            return new WrappedDisposable<StreamWriter>(new StreamWriter(FilePath, append, Encoding.UTF8));
 #endif
         }
 


### PR DESCRIPTION
The projects that we are using exceptionless client sdk with, have been developed and deployed in Simplified Chinese Windows environment. When there are some system errors occurred, the content in exceptionless.log file will be messy. So the encoding of logging writer should be changed to Encoding.UTF8 to compatible the variety cultures.