### PR TITLE
Replace GetFiles with EnumerateFiles method to improve peformance in FolderObjectStorage

### DIFF
--- a/src/Exceptionless/Storage/FolderObjectStorage.cs
+++ b/src/Exceptionless/Storage/FolderObjectStorage.cs
@@ -121,7 +121,7 @@ namespace Exceptionless.Storage {
 
             var list = new List<ObjectInfo>();
 
-            foreach (var path in Directory.GetFiles(Folder, searchPattern, SearchOption.AllDirectories)) {
+            foreach (var path in Directory.EnumerateFiles(Folder, searchPattern, SearchOption.AllDirectories)) {
                 var info = new System.IO.FileInfo(path);
                 if (!info.Exists || info.CreationTime > maxCreatedDate)
                     continue;


### PR DESCRIPTION
Replace GetFiles with EnumerateFiles method to improve peformance of FolderObjectStorage while retrieving object list. Especially in the high throughput scenarios, there will be more than thousands files, the performance of GetFiles will be very bad. So replace with EnumerateFiles can be very fast to retrieve file name with limit. Please refer to [https://stackoverflow.com/questions/5669617/what-is-the-difference-between-directory-enumeratefiles-vs-directory-getfiles](https://stackoverflow.com/questions/5669617/what-is-the-difference-between-directory-enumeratefiles-vs-directory-getfiles)