### PR TITLE
Add event time and level for the file logger.

### DIFF
--- a/test/Exceptionless.Tests/Log/FileExceptionlessLogTestBase.cs
+++ b/test/Exceptionless.Tests/Log/FileExceptionlessLogTestBase.cs
@@ -18,7 +18,7 @@ namespace Exceptionless.Tests.Log {
                 Assert.True(LogExists());
                 string contents = log.GetFileContents();
 
-                Assert.Equal("Test\r\n", contents);
+                Assert.EndsWith(" Info  Test\r\n", contents);
             }
         }
 
@@ -36,7 +36,7 @@ namespace Exceptionless.Tests.Log {
                 Assert.True(LogExists());
                 contents = log.GetFileContents();
 
-                Assert.Equal("Test\r\n", contents);
+                Assert.EndsWith(" Info  Test\r\n", contents);
             }
         }
 


### PR DESCRIPTION
The original file logger cannot record event time and level. It's hard to know when the error occurs, and which one is warn or error.