### PR TITLE
Release lock before calling unknown code.

### DIFF
--- a/src/Exceptionless/Plugins/Default/1010_DuplicateCheckerPlugin.cs
+++ b/src/Exceptionless/Plugins/Default/1010_DuplicateCheckerPlugin.cs
@@ -72,10 +72,17 @@ namespace Exceptionless.Plugins.Default {
         }
 
         private void EnqueueMergedEvents() {
-            lock (_lock) {
-                while (_mergedEvents.Count > 0)
-                    _mergedEvents.Dequeue().Resubmit();
-            }
+            bool more;
+            do {
+                MergedEvent mergedEvent = null;
+                lock (_lock) {
+                    if (_mergedEvents.Count > 0) {
+                        mergedEvent = _mergedEvents.Dequeue();
+                    }
+                    more = _mergedEvents.Count > 0;
+                }
+                mergedEvent?.Resubmit();
+            } while (more);
         }
 
         public void Dispose() {


### PR DESCRIPTION
Fixes issue #182. 

I've fixed without changing the underlying data structures. Instead I just ensure the lock is released when resubmitting the MergedEvent. This ensures we can't cause a deadlock by some unknown code running from the ExceptionlessClient callbacks (SubmittingEvent). 

- There are no tests as it's not worth it for a deadlock.
- I tried to sign your CLA but got "We're sorry, but something went wrong."