### PR TITLE
Make json.net internal

### DIFF
--- a/src/Exceptionless/EventBuilder.cs
+++ b/src/Exceptionless/EventBuilder.cs
@@ -115,7 +115,7 @@ namespace Exceptionless {
 
         /// <summary>
         /// Sets an extended property value to include with the event. Use either <paramref name="excludedPropertyNames" /> or
-        /// <see cref="Exceptionless.Json.JsonIgnoreAttribute" /> to exclude data from being included in the event report.
+        /// <see cref="Exceptionless.Json.DataMemberIgnoreAttribute" /> to exclude data from being included in the event report.
         /// </summary>
         /// <param name="name">The name of the object to add.</param>
         /// <param name="value">The data object to add.</param>
@@ -131,7 +131,7 @@ namespace Exceptionless {
 
         /// <summary>
         /// Adds the object to extended data. Use either <paramref name="excludedPropertyNames" /> or
-        /// <see cref="Exceptionless.Json.JsonIgnoreAttribute" /> to exclude data from being included in the event.
+        /// <see cref="Exceptionless.Json.DataMemberIgnoreAttribute" /> to exclude data from being included in the event.
         /// </summary>
         /// <param name="data">The data object to add.</param>
         /// <param name="name">The name of the object to add.</param>

--- a/src/Exceptionless/Newtonsoft.Json/Bson/BsonObjectId.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Bson/BsonObjectId.cs
@@ -31,7 +31,7 @@ namespace Exceptionless.Json.Bson
     /// <summary>
     /// Represents a BSON Oid (object id).
     /// </summary>
-    public class BsonObjectId
+    internal class BsonObjectId
     {
         /// <summary>
         /// Gets or sets the value of the Oid.

--- a/src/Exceptionless/Newtonsoft.Json/Bson/BsonReader.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Bson/BsonReader.cs
@@ -37,7 +37,7 @@ namespace Exceptionless.Json.Bson
     /// <summary>
     /// Represents a reader that provides fast, non-cached, forward-only access to serialized JSON data.
     /// </summary>
-    public class BsonReader : JsonReader
+    internal class BsonReader : JsonReader
     {
         private const int MaxCharBytesSize = 128;
         private static readonly byte[] SeqRange1 = new byte[] { 0, 127 }; // range of 1-byte sequence

--- a/src/Exceptionless/Newtonsoft.Json/Bson/BsonWriter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Bson/BsonWriter.cs
@@ -40,7 +40,7 @@ namespace Exceptionless.Json.Bson
     /// <summary>
     /// Represents a writer that provides a fast, non-cached, forward-only way of generating JSON data.
     /// </summary>
-    public class BsonWriter : JsonWriter
+    internal class BsonWriter : JsonWriter
     {
         private readonly BsonBinaryWriter _writer;
 
@@ -294,7 +294,7 @@ namespace Exceptionless.Json.Bson
         /// Writes a <see cref="UInt32"/> value.
         /// </summary>
         /// <param name="value">The <see cref="UInt32"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public override void WriteValue(uint value)
         {
             if (value > int.MaxValue)
@@ -320,7 +320,7 @@ namespace Exceptionless.Json.Bson
         /// Writes a <see cref="UInt64"/> value.
         /// </summary>
         /// <param name="value">The <see cref="UInt64"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public override void WriteValue(ulong value)
         {
             if (value > long.MaxValue)
@@ -376,7 +376,7 @@ namespace Exceptionless.Json.Bson
         /// Writes a <see cref="UInt16"/> value.
         /// </summary>
         /// <param name="value">The <see cref="UInt16"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public override void WriteValue(ushort value)
         {
             base.WriteValue(value);
@@ -413,7 +413,7 @@ namespace Exceptionless.Json.Bson
         /// Writes a <see cref="SByte"/> value.
         /// </summary>
         /// <param name="value">The <see cref="SByte"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public override void WriteValue(sbyte value)
         {
             base.WriteValue(value);

--- a/src/Exceptionless/Newtonsoft.Json/ConstructorHandling.cs
+++ b/src/Exceptionless/Newtonsoft.Json/ConstructorHandling.cs
@@ -28,7 +28,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Specifies how constructors are used when initializing objects during deserialization by the <see cref="JsonSerializer"/>.
     /// </summary>
-    public enum ConstructorHandling
+    internal enum ConstructorHandling
     {
         /// <summary>
         /// First attempt to use the public default constructor, then fall back to single paramatized constructor, then the non-public default constructor.

--- a/src/Exceptionless/Newtonsoft.Json/Converters/BinaryConverter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Converters/BinaryConverter.cs
@@ -37,7 +37,7 @@ namespace Exceptionless.Json.Converters
     /// <summary>
     /// Converts a binary value to and from a base 64 string value.
     /// </summary>
-    public class BinaryConverter : JsonConverter
+    internal class BinaryConverter : JsonConverter
     {
 #if !NET20
         private const string BinaryTypeName = "System.Data.Linq.Binary";

--- a/src/Exceptionless/Newtonsoft.Json/Converters/BsonObjectIdConverter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Converters/BsonObjectIdConverter.cs
@@ -33,7 +33,7 @@ namespace Exceptionless.Json.Converters
     /// <summary>
     /// Converts a <see cref="BsonObjectId"/> to and from JSON and BSON.
     /// </summary>
-    public class BsonObjectIdConverter : JsonConverter
+    internal class BsonObjectIdConverter : JsonConverter
     {
         /// <summary>
         /// Writes the JSON representation of the object.

--- a/src/Exceptionless/Newtonsoft.Json/Converters/CustomCreationConverter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Converters/CustomCreationConverter.cs
@@ -33,7 +33,7 @@ namespace Exceptionless.Json.Converters
     /// Create a custom object
     /// </summary>
     /// <typeparam name="T">The object type to convert.</typeparam>
-    public abstract class CustomCreationConverter<T> : JsonConverter
+    internal abstract class CustomCreationConverter<T> : JsonConverter
     {
         /// <summary>
         /// Writes the JSON representation of the object.

--- a/src/Exceptionless/Newtonsoft.Json/Converters/DataSetConverter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Converters/DataSetConverter.cs
@@ -33,7 +33,7 @@ namespace Exceptionless.Json.Converters
     /// <summary>
     /// Converts a <see cref="DataSet"/> to and from JSON.
     /// </summary>
-    public class DataSetConverter : JsonConverter
+    internal class DataSetConverter : JsonConverter
     {
         /// <summary>
         /// Writes the JSON representation of the object.

--- a/src/Exceptionless/Newtonsoft.Json/Converters/DataTableConverter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Converters/DataTableConverter.cs
@@ -36,7 +36,7 @@ namespace Exceptionless.Json.Converters
     /// <summary>
     /// Converts a <see cref="DataTable"/> to and from JSON.
     /// </summary>
-    public class DataTableConverter : JsonConverter
+    internal class DataTableConverter : JsonConverter
     {
         /// <summary>
         /// Writes the JSON representation of the object.

--- a/src/Exceptionless/Newtonsoft.Json/Converters/DateTimeConverterBase.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Converters/DateTimeConverterBase.cs
@@ -30,7 +30,7 @@ namespace Exceptionless.Json.Converters
     /// <summary>
     /// Provides a base class for converting a <see cref="DateTime"/> to and from JSON.
     /// </summary>
-    public abstract class DateTimeConverterBase : JsonConverter
+    internal abstract class DateTimeConverterBase : JsonConverter
     {
         /// <summary>
         /// Determines whether this instance can convert the specified object type.

--- a/src/Exceptionless/Newtonsoft.Json/Converters/DiscriminatedUnionConverter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Converters/DiscriminatedUnionConverter.cs
@@ -43,7 +43,7 @@ namespace Exceptionless.Json.Converters
     /// <summary>
     /// Converts a F# discriminated union type to and from JSON.
     /// </summary>
-    public class DiscriminatedUnionConverter : JsonConverter
+    internal class DiscriminatedUnionConverter : JsonConverter
     {
         #region UnionDefinition
         internal class Union

--- a/src/Exceptionless/Newtonsoft.Json/Converters/EntityKeyMemberConverter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Converters/EntityKeyMemberConverter.cs
@@ -34,7 +34,7 @@ namespace Exceptionless.Json.Converters
     /// <summary>
     /// Converts an Entity Framework EntityKey to and from JSON.
     /// </summary>
-    public class EntityKeyMemberConverter : JsonConverter
+    internal class EntityKeyMemberConverter : JsonConverter
     {
         private const string EntityKeyMemberFullTypeName = "System.Data.EntityKeyMember";
 

--- a/src/Exceptionless/Newtonsoft.Json/Converters/ExpandoObjectConverter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Converters/ExpandoObjectConverter.cs
@@ -38,7 +38,7 @@ namespace Exceptionless.Json.Converters
     /// <summary>
     /// Converts an ExpandoObject to and from JSON.
     /// </summary>
-    public class ExpandoObjectConverter : JsonConverter
+    internal class ExpandoObjectConverter : JsonConverter
     {
         /// <summary>
         /// Writes the JSON representation of the object.

--- a/src/Exceptionless/Newtonsoft.Json/Converters/IsoDateTimeConverter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Converters/IsoDateTimeConverter.cs
@@ -32,7 +32,7 @@ namespace Exceptionless.Json.Converters
     /// <summary>
     /// Converts a <see cref="DateTime"/> to and from the ISO 8601 date format (e.g. 2008-04-12T12:53Z).
     /// </summary>
-    public class IsoDateTimeConverter : DateTimeConverterBase
+    internal class IsoDateTimeConverter : DateTimeConverterBase
     {
         private const string DefaultDateTimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK";
 

--- a/src/Exceptionless/Newtonsoft.Json/Converters/JavaScriptDateTimeConverter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Converters/JavaScriptDateTimeConverter.cs
@@ -32,7 +32,7 @@ namespace Exceptionless.Json.Converters
     /// <summary>
     /// Converts a <see cref="DateTime"/> to and from a JavaScript date constructor (e.g. new Date(52231943)).
     /// </summary>
-    public class JavaScriptDateTimeConverter : DateTimeConverterBase
+    internal class JavaScriptDateTimeConverter : DateTimeConverterBase
     {
         /// <summary>
         /// Writes the JSON representation of the object.

--- a/src/Exceptionless/Newtonsoft.Json/Converters/JsonValueConverter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Converters/JsonValueConverter.cs
@@ -37,7 +37,7 @@ namespace Exceptionless.Json.Converters
     /// <summary>
     /// Converts a <see cref="IJsonValue"/> to and from JSON.
     /// </summary>
-    public class JsonValueConverter : JsonConverter
+    internal class JsonValueConverter : JsonConverter
     {
         /// <summary>
         /// Writes the JSON representation of the object.

--- a/src/Exceptionless/Newtonsoft.Json/Converters/KeyValuePairConverter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Converters/KeyValuePairConverter.cs
@@ -34,7 +34,7 @@ namespace Exceptionless.Json.Converters
     /// <summary>
     /// Converts a <see cref="KeyValuePair{TKey,TValue}"/> to and from JSON.
     /// </summary>
-    public class KeyValuePairConverter : JsonConverter
+    internal class KeyValuePairConverter : JsonConverter
     {
         private const string KeyName = "Key";
         private const string ValueName = "Value";

--- a/src/Exceptionless/Newtonsoft.Json/Converters/RegexConverter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Converters/RegexConverter.cs
@@ -34,7 +34,7 @@ namespace Exceptionless.Json.Converters
     /// <summary>
     /// Converts a <see cref="Regex"/> to and from JSON and BSON.
     /// </summary>
-    public class RegexConverter : JsonConverter
+    internal class RegexConverter : JsonConverter
     {
         private const string PatternName = "Pattern";
         private const string OptionsName = "Options";

--- a/src/Exceptionless/Newtonsoft.Json/Converters/StringEnumConverter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Converters/StringEnumConverter.cs
@@ -41,7 +41,7 @@ namespace Exceptionless.Json.Converters
     /// <summary>
     /// Converts an <see cref="Enum"/> to and from its name string value.
     /// </summary>
-    public class StringEnumConverter : JsonConverter
+    internal class StringEnumConverter : JsonConverter
     {
         /// <summary>
         /// Gets or sets a value indicating whether the written enum text should be camel case.

--- a/src/Exceptionless/Newtonsoft.Json/Converters/VersionConverter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Converters/VersionConverter.cs
@@ -32,7 +32,7 @@ namespace Exceptionless.Json.Converters
     /// <summary>
     /// Converts a <see cref="Version"/> to and from a string (e.g. "1.2.3.4").
     /// </summary>
-    public class VersionConverter : JsonConverter
+    internal class VersionConverter : JsonConverter
     {
         /// <summary>
         /// Writes the JSON representation of the object.

--- a/src/Exceptionless/Newtonsoft.Json/Converters/XmlNodeConverter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Converters/XmlNodeConverter.cs
@@ -922,7 +922,7 @@ namespace Exceptionless.Json.Converters
     /// <summary>
     /// Converts XML to and from JSON.
     /// </summary>
-    public class XmlNodeConverter : JsonConverter
+    internal class XmlNodeConverter : JsonConverter
     {
         private const string TextName = "#text";
         private const string CommentName = "#comment";

--- a/src/Exceptionless/Newtonsoft.Json/DataMemberIgnoreAttribute.cs
+++ b/src/Exceptionless/Newtonsoft.Json/DataMemberIgnoreAttribute.cs
@@ -33,7 +33,7 @@ namespace Exceptionless.Json
     /// Instructs the <see cref="JsonSerializer"/> not to serialize the public field or public read/write property value.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false)]
-    internal sealed class DataMemberIgnoreAttribute : Attribute
+    public sealed class DataMemberIgnoreAttribute : Attribute
     {
     }
 }

--- a/src/Exceptionless/Newtonsoft.Json/DataMemberIgnoreAttribute.cs
+++ b/src/Exceptionless/Newtonsoft.Json/DataMemberIgnoreAttribute.cs
@@ -33,7 +33,7 @@ namespace Exceptionless.Json
     /// Instructs the <see cref="JsonSerializer"/> not to serialize the public field or public read/write property value.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false)]
-    internal sealed class JsonIgnoreAttribute : Attribute
+    internal sealed class DataMemberIgnoreAttribute : Attribute
     {
     }
 }

--- a/src/Exceptionless/Newtonsoft.Json/DateFormatHandling.cs
+++ b/src/Exceptionless/Newtonsoft.Json/DateFormatHandling.cs
@@ -28,7 +28,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Specifies how dates are formatted when writing JSON text.
     /// </summary>
-    public enum DateFormatHandling
+    internal enum DateFormatHandling
     {
         /// <summary>
         /// Dates are written in the ISO 8601 format, e.g. "2012-03-21T05:40Z".

--- a/src/Exceptionless/Newtonsoft.Json/DateParseHandling.cs
+++ b/src/Exceptionless/Newtonsoft.Json/DateParseHandling.cs
@@ -28,7 +28,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Specifies how date formatted strings, e.g. "\/Date(1198908717056)\/" and "2012-03-21T05:40Z", are parsed when reading JSON text.
     /// </summary>
-    public enum DateParseHandling
+    internal enum DateParseHandling
     {
         /// <summary>
         /// Date formatted strings are not parsed to a date type and are read as strings.

--- a/src/Exceptionless/Newtonsoft.Json/DateTimeZoneHandling.cs
+++ b/src/Exceptionless/Newtonsoft.Json/DateTimeZoneHandling.cs
@@ -30,7 +30,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Specifies how to treat the time value when converting between string and <see cref="DateTime"/>.
     /// </summary>
-    public enum DateTimeZoneHandling
+    internal enum DateTimeZoneHandling
     {
         /// <summary>
         /// Treat as local time. If the <see cref="DateTime"/> object represents a Coordinated Universal Time (UTC), it is converted to the local time.

--- a/src/Exceptionless/Newtonsoft.Json/DefaultValueHandling.cs
+++ b/src/Exceptionless/Newtonsoft.Json/DefaultValueHandling.cs
@@ -36,7 +36,7 @@ namespace Exceptionless.Json
     ///   <code lang="cs" source="..\Src\Exceptionless.Json.Tests\Documentation\SerializationTests.cs" region="ReducingSerializedJsonSizeDefaultValueHandlingExample" title="DefaultValueHandling Ignore Example" />
     /// </example>
     [Flags]
-    public enum DefaultValueHandling
+    internal enum DefaultValueHandling
     {
         /// <summary>
         /// Include members where the member value is the same as the member's default value when serializing objects.

--- a/src/Exceptionless/Newtonsoft.Json/FloatFormatHandling.cs
+++ b/src/Exceptionless/Newtonsoft.Json/FloatFormatHandling.cs
@@ -29,7 +29,7 @@ namespace Exceptionless.Json
     /// Specifies float format handling options when writing special floating point numbers, e.g. <see cref="F:System.Double.NaN"/>,
     /// <see cref="F:System.Double.PositiveInfinity"/> and <see cref="F:System.Double.NegativeInfinity"/> with <see cref="JsonWriter"/>.
     /// </summary>
-    public enum FloatFormatHandling
+    internal enum FloatFormatHandling
     {
         /// <summary>
         /// Write special floating point values as strings in JSON, e.g. "NaN", "Infinity", "-Infinity".

--- a/src/Exceptionless/Newtonsoft.Json/FloatParseHandling.cs
+++ b/src/Exceptionless/Newtonsoft.Json/FloatParseHandling.cs
@@ -28,7 +28,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Specifies how floating point numbers, e.g. 1.0 and 9.9, are parsed when reading JSON text.
     /// </summary>
-    public enum FloatParseHandling
+    internal enum FloatParseHandling
     {
         /// <summary>
         /// Floating point numbers are parsed to <see cref="Double"/>.

--- a/src/Exceptionless/Newtonsoft.Json/FormatterAssemblyStyle.cs
+++ b/src/Exceptionless/Newtonsoft.Json/FormatterAssemblyStyle.cs
@@ -6,7 +6,7 @@ namespace System.Runtime.Serialization.Formatters
     /// <summary>
     /// Indicates the method that will be used during deserialization for locating and loading assemblies.
     /// </summary>
-    public enum FormatterAssemblyStyle
+    internal enum FormatterAssemblyStyle
     {
         /// <summary>
         /// In simple mode, the assembly used during deserialization need not match exactly the assembly used during serialization. Specifically, the version numbers need not match as the LoadWithPartialName method is used to load the assembly.

--- a/src/Exceptionless/Newtonsoft.Json/Formatting.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Formatting.cs
@@ -28,7 +28,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Specifies formatting options for the <see cref="JsonTextWriter"/>.
     /// </summary>
-    public enum Formatting
+    internal enum Formatting
     {
         /// <summary>
         /// No special formatting is applied. This is the default.

--- a/src/Exceptionless/Newtonsoft.Json/IArrayPool.cs
+++ b/src/Exceptionless/Newtonsoft.Json/IArrayPool.cs
@@ -4,7 +4,7 @@ namespace Exceptionless.Json
     /// Provides an interface for using pooled arrays.
     /// </summary>
     /// <typeparam name="T">The array type content.</typeparam>
-    public interface IArrayPool<T>
+    internal interface IArrayPool<T>
     {
         /// <summary>
         /// Rent a array from the pool. This array must be returned when it is no longer needed.

--- a/src/Exceptionless/Newtonsoft.Json/IJsonLineInfo.cs
+++ b/src/Exceptionless/Newtonsoft.Json/IJsonLineInfo.cs
@@ -28,7 +28,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Provides an interface to enable a class to return line and position information.
     /// </summary>
-    public interface IJsonLineInfo
+    internal interface IJsonLineInfo
     {
         /// <summary>
         /// Gets a value indicating whether the class can return line information.

--- a/src/Exceptionless/Newtonsoft.Json/JsonArrayAttribute.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonArrayAttribute.cs
@@ -31,7 +31,7 @@ namespace Exceptionless.Json
     /// Instructs the <see cref="JsonSerializer"/> how to serialize the collection.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false)]
-    public sealed class JsonArrayAttribute : JsonContainerAttribute
+    internal sealed class JsonArrayAttribute : JsonContainerAttribute
     {
         private bool _allowNullItems;
 

--- a/src/Exceptionless/Newtonsoft.Json/JsonConstructorAttribute.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonConstructorAttribute.cs
@@ -31,7 +31,7 @@ namespace Exceptionless.Json
     /// Instructs the <see cref="JsonSerializer"/> to use the specified constructor when deserializing that object.
     /// </summary>
     [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false)]
-    public sealed class JsonConstructorAttribute : Attribute
+    internal sealed class JsonConstructorAttribute : Attribute
     {
     }
 }

--- a/src/Exceptionless/Newtonsoft.Json/JsonContainerAttribute.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonContainerAttribute.cs
@@ -31,7 +31,7 @@ namespace Exceptionless.Json
     /// Instructs the <see cref="JsonSerializer"/> how to serialize the object.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false)]
-    public abstract class JsonContainerAttribute : Attribute
+    internal abstract class JsonContainerAttribute : Attribute
     {
         /// <summary>
         /// Gets or sets the id.

--- a/src/Exceptionless/Newtonsoft.Json/JsonConvert.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonConvert.cs
@@ -51,7 +51,7 @@ namespace Exceptionless.Json
     /// <example>
     ///   <code lang="cs" source="..\Src\Exceptionless.Json.Tests\Documentation\SerializationTests.cs" region="SerializeObject" title="Serializing and Deserializing JSON with JsonConvert" />
     /// </example>
-    public static class JsonConvert
+    internal static class JsonConvert
     {
         /// <summary>
         /// Gets or sets a function that creates default <see cref="JsonSerializerSettings"/>.
@@ -211,7 +211,7 @@ namespace Exceptionless.Json
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>A JSON string representation of the <see cref="UInt16"/>.</returns>
-        [CLSCompliant(false)]
+        
         public static string ToString(ushort value)
         {
             return value.ToString(null, CultureInfo.InvariantCulture);
@@ -222,7 +222,7 @@ namespace Exceptionless.Json
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>A JSON string representation of the <see cref="UInt32"/>.</returns>
-        [CLSCompliant(false)]
+        
         public static string ToString(uint value)
         {
             return value.ToString(null, CultureInfo.InvariantCulture);
@@ -250,7 +250,7 @@ namespace Exceptionless.Json
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>A JSON string representation of the <see cref="UInt64"/>.</returns>
-        [CLSCompliant(false)]
+        
         public static string ToString(ulong value)
         {
             return value.ToString(null, CultureInfo.InvariantCulture);
@@ -336,7 +336,7 @@ namespace Exceptionless.Json
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>A JSON string representation of the <see cref="SByte"/>.</returns>
-        [CLSCompliant(false)]
+        
         public static string ToString(sbyte value)
         {
             return value.ToString(null, CultureInfo.InvariantCulture);

--- a/src/Exceptionless/Newtonsoft.Json/JsonConverter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonConverter.cs
@@ -34,7 +34,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Converts an object to and from JSON.
     /// </summary>
-    public abstract class JsonConverter
+    internal abstract class JsonConverter
     {
         /// <summary>
         /// Writes the JSON representation of the object.

--- a/src/Exceptionless/Newtonsoft.Json/JsonConverterAttribute.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonConverterAttribute.cs
@@ -33,7 +33,7 @@ namespace Exceptionless.Json
     /// Instructs the <see cref="JsonSerializer"/> to use the specified <see cref="JsonConverter"/> when serializing the member or class.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface | AttributeTargets.Enum | AttributeTargets.Parameter, AllowMultiple = false)]
-    public sealed class JsonConverterAttribute : Attribute
+    internal sealed class JsonConverterAttribute : Attribute
     {
         private readonly Type _converterType;
 

--- a/src/Exceptionless/Newtonsoft.Json/JsonConverterCollection.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonConverterCollection.cs
@@ -33,7 +33,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Represents a collection of <see cref="JsonConverter"/>.
     /// </summary>
-    public class JsonConverterCollection : Collection<JsonConverter>
+    internal class JsonConverterCollection : Collection<JsonConverter>
     {
     }
 }

--- a/src/Exceptionless/Newtonsoft.Json/JsonDictionaryAttribute.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonDictionaryAttribute.cs
@@ -31,7 +31,7 @@ namespace Exceptionless.Json
     /// Instructs the <see cref="JsonSerializer"/> how to serialize the collection.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false)]
-    public sealed class JsonDictionaryAttribute : JsonContainerAttribute
+    internal sealed class JsonDictionaryAttribute : JsonContainerAttribute
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonDictionaryAttribute"/> class.

--- a/src/Exceptionless/Newtonsoft.Json/JsonException.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonException.cs
@@ -38,7 +38,7 @@ namespace Exceptionless.Json
 #if !(DOTNET || PORTABLE40 || PORTABLE || NETSTANDARD1_0 || NETSTANDARD1_1 || NETSTANDARD1_2 || NETSTANDARD1_3 || NETSTANDARD1_4 || NETSTANDARD1_5)
     [Serializable]
 #endif
-    public class JsonException : Exception
+    internal class JsonException : Exception
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonException"/> class.

--- a/src/Exceptionless/Newtonsoft.Json/JsonExtensionDataAttribute.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonExtensionDataAttribute.cs
@@ -7,7 +7,7 @@ namespace Exceptionless.Json
     /// and write values during serialization.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false)]
-    public class JsonExtensionDataAttribute : Attribute
+    internal class JsonExtensionDataAttribute : Attribute
     {
         /// <summary>
         /// Gets or sets a value that indicates whether to write extension data when serializing the object.

--- a/src/Exceptionless/Newtonsoft.Json/JsonIgnoreAttribute.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonIgnoreAttribute.cs
@@ -33,7 +33,7 @@ namespace Exceptionless.Json
     /// Instructs the <see cref="JsonSerializer"/> not to serialize the public field or public read/write property value.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false)]
-    public sealed class JsonIgnoreAttribute : Attribute
+    internal sealed class JsonIgnoreAttribute : Attribute
     {
     }
 }

--- a/src/Exceptionless/Newtonsoft.Json/JsonObjectAttribute.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonObjectAttribute.cs
@@ -31,7 +31,7 @@ namespace Exceptionless.Json
     /// Instructs the <see cref="JsonSerializer"/> how to serialize the object.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, AllowMultiple = false)]
-    public sealed class JsonObjectAttribute : JsonContainerAttribute
+    internal sealed class JsonObjectAttribute : JsonContainerAttribute
     {
         private MemberSerialization _memberSerialization = MemberSerialization.OptOut;
 

--- a/src/Exceptionless/Newtonsoft.Json/JsonPropertyAttribute.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonPropertyAttribute.cs
@@ -31,7 +31,7 @@ namespace Exceptionless.Json
     /// Instructs the <see cref="JsonSerializer"/> to always serialize the member with the specified name.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false)]
-    public sealed class JsonPropertyAttribute : Attribute
+    internal sealed class JsonPropertyAttribute : Attribute
     {
         // yuck. can't set nullable properties on an attribute in C#
         // have to use this approach to get an unset default state

--- a/src/Exceptionless/Newtonsoft.Json/JsonReader.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonReader.cs
@@ -43,7 +43,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Represents a reader that provides fast, non-cached, forward-only access to serialized JSON data.
     /// </summary>
-    public abstract class JsonReader : IDisposable
+    internal abstract class JsonReader : IDisposable
     {
         /// <summary>
         /// Specifies the state of the reader.

--- a/src/Exceptionless/Newtonsoft.Json/JsonReaderException.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonReaderException.cs
@@ -36,7 +36,7 @@ namespace Exceptionless.Json
 #if !(DOTNET || PORTABLE || PORTABLE40 || NETSTANDARD1_0 || NETSTANDARD1_1 || NETSTANDARD1_2 || NETSTANDARD1_3 || NETSTANDARD1_4 || NETSTANDARD1_5)
     [Serializable]
 #endif
-    public class JsonReaderException : JsonException
+    internal class JsonReaderException : JsonException
     {
         /// <summary>
         /// Gets the line number indicating where the error occurred.

--- a/src/Exceptionless/Newtonsoft.Json/JsonRequiredAttribute.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonRequiredAttribute.cs
@@ -33,7 +33,7 @@ namespace Exceptionless.Json
     /// Instructs the <see cref="JsonSerializer"/> to always serialize the member, and require the member has a value.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false)]
-    public sealed class JsonRequiredAttribute : Attribute
+    internal sealed class JsonRequiredAttribute : Attribute
     {
     }
 }

--- a/src/Exceptionless/Newtonsoft.Json/JsonSerializationException.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonSerializationException.cs
@@ -36,7 +36,7 @@ namespace Exceptionless.Json
 #if !(DOTNET || PORTABLE40 || PORTABLE || NETSTANDARD1_0 || NETSTANDARD1_1 || NETSTANDARD1_2 || NETSTANDARD1_3 || NETSTANDARD1_4 || NETSTANDARD1_5)
     [Serializable]
 #endif
-    public class JsonSerializationException : JsonException
+    internal class JsonSerializationException : JsonException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonSerializationException"/> class.

--- a/src/Exceptionless/Newtonsoft.Json/JsonSerializer.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonSerializer.cs
@@ -42,7 +42,7 @@ namespace Exceptionless.Json
     /// Serializes and deserializes objects into and from the JSON format.
     /// The <see cref="JsonSerializer"/> enables you to control how objects are encoded into JSON.
     /// </summary>
-    public class JsonSerializer
+    internal class JsonSerializer
     {
         internal TypeNameHandling _typeNameHandling;
         internal FormatterAssemblyStyle _typeNameAssemblyFormat;

--- a/src/Exceptionless/Newtonsoft.Json/JsonSerializerSettings.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonSerializerSettings.cs
@@ -36,7 +36,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Specifies the settings on a <see cref="JsonSerializer"/> object.
     /// </summary>
-    public class JsonSerializerSettings
+    internal class JsonSerializerSettings
     {
         internal const ReferenceLoopHandling DefaultReferenceLoopHandling = ReferenceLoopHandling.Error;
         internal const MissingMemberHandling DefaultMissingMemberHandling = MissingMemberHandling.Ignore;

--- a/src/Exceptionless/Newtonsoft.Json/JsonTextReader.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonTextReader.cs
@@ -55,7 +55,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Represents a reader that provides fast, non-cached, forward-only access to JSON text data.
     /// </summary>
-    public class JsonTextReader : JsonReader, IJsonLineInfo
+    internal class JsonTextReader : JsonReader, IJsonLineInfo
     {
         private const char UnicodeReplacementChar = '\uFFFD';
         private const int MaximumJavascriptIntegerCharacterLength = 380;

--- a/src/Exceptionless/Newtonsoft.Json/JsonTextWriter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonTextWriter.cs
@@ -39,7 +39,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Represents a writer that provides a fast, non-cached, forward-only way of generating JSON data.
     /// </summary>
-    public class JsonTextWriter : JsonWriter
+    internal class JsonTextWriter : JsonWriter
     {
         private readonly TextWriter _writer;
         private Base64Encoder _base64Encoder;
@@ -439,7 +439,7 @@ namespace Exceptionless.Json
         /// Writes a <see cref="UInt32"/> value.
         /// </summary>
         /// <param name="value">The <see cref="UInt32"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public override void WriteValue(uint value)
         {
             InternalWriteValue(JsonToken.Integer);
@@ -460,7 +460,7 @@ namespace Exceptionless.Json
         /// Writes a <see cref="UInt64"/> value.
         /// </summary>
         /// <param name="value">The <see cref="UInt64"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public override void WriteValue(ulong value)
         {
             InternalWriteValue(JsonToken.Integer);
@@ -545,7 +545,7 @@ namespace Exceptionless.Json
         /// Writes a <see cref="UInt16"/> value.
         /// </summary>
         /// <param name="value">The <see cref="UInt16"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public override void WriteValue(ushort value)
         {
             InternalWriteValue(JsonToken.Integer);
@@ -576,7 +576,7 @@ namespace Exceptionless.Json
         /// Writes a <see cref="SByte"/> value.
         /// </summary>
         /// <param name="value">The <see cref="SByte"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public override void WriteValue(sbyte value)
         {
             InternalWriteValue(JsonToken.Integer);

--- a/src/Exceptionless/Newtonsoft.Json/JsonToken.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonToken.cs
@@ -32,7 +32,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Specifies the type of JSON token.
     /// </summary>
-    public enum JsonToken
+    internal enum JsonToken
     {
         /// <summary>
         /// This is returned by the <see cref="JsonReader"/> if a <see cref="JsonReader.Read"/> method has not been called. 

--- a/src/Exceptionless/Newtonsoft.Json/JsonValidatingReader.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonValidatingReader.cs
@@ -52,7 +52,7 @@ namespace Exceptionless.Json
     /// </note>
     /// </summary>
     [Obsolete("JSON Schema validation has been moved to its own package. See http://www.newtonsoft.com/jsonschema for more details.")]
-    public class JsonValidatingReader : JsonReader, IJsonLineInfo
+    internal class JsonValidatingReader : JsonReader, IJsonLineInfo
     {
         private class SchemaScope
         {

--- a/src/Exceptionless/Newtonsoft.Json/JsonWriter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonWriter.cs
@@ -43,7 +43,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Represents a writer that provides a fast, non-cached, forward-only way of generating JSON data.
     /// </summary>
-    public abstract class JsonWriter : IDisposable
+    internal abstract class JsonWriter : IDisposable
     {
         internal enum State
         {
@@ -928,7 +928,7 @@ namespace Exceptionless.Json
         /// Writes a <see cref="UInt32"/> value.
         /// </summary>
         /// <param name="value">The <see cref="UInt32"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public virtual void WriteValue(uint value)
         {
             InternalWriteValue(JsonToken.Integer);
@@ -947,7 +947,7 @@ namespace Exceptionless.Json
         /// Writes a <see cref="UInt64"/> value.
         /// </summary>
         /// <param name="value">The <see cref="UInt64"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public virtual void WriteValue(ulong value)
         {
             InternalWriteValue(JsonToken.Integer);
@@ -993,7 +993,7 @@ namespace Exceptionless.Json
         /// Writes a <see cref="UInt16"/> value.
         /// </summary>
         /// <param name="value">The <see cref="UInt16"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public virtual void WriteValue(ushort value)
         {
             InternalWriteValue(JsonToken.Integer);
@@ -1021,7 +1021,7 @@ namespace Exceptionless.Json
         /// Writes a <see cref="SByte"/> value.
         /// </summary>
         /// <param name="value">The <see cref="SByte"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public virtual void WriteValue(sbyte value)
         {
             InternalWriteValue(JsonToken.Integer);
@@ -1094,7 +1094,7 @@ namespace Exceptionless.Json
         /// Writes a <see cref="Nullable{UInt32}"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Nullable{UInt32}"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public virtual void WriteValue(uint? value)
         {
             if (value == null)
@@ -1127,7 +1127,7 @@ namespace Exceptionless.Json
         /// Writes a <see cref="Nullable{UInt64}"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Nullable{UInt64}"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public virtual void WriteValue(ulong? value)
         {
             if (value == null)
@@ -1208,7 +1208,7 @@ namespace Exceptionless.Json
         /// Writes a <see cref="Nullable{UInt16}"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Nullable{UInt16}"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public virtual void WriteValue(ushort? value)
         {
             if (value == null)
@@ -1257,7 +1257,7 @@ namespace Exceptionless.Json
         /// Writes a <see cref="Nullable{SByte}"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Nullable{SByte}"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public virtual void WriteValue(sbyte? value)
         {
             if (value == null)

--- a/src/Exceptionless/Newtonsoft.Json/JsonWriterException.cs
+++ b/src/Exceptionless/Newtonsoft.Json/JsonWriterException.cs
@@ -36,7 +36,7 @@ namespace Exceptionless.Json
 #if !(DOTNET || PORTABLE40 || PORTABLE || NETSTANDARD1_0 || NETSTANDARD1_1 || NETSTANDARD1_2 || NETSTANDARD1_3 || NETSTANDARD1_4 || NETSTANDARD1_5)
     [Serializable]
 #endif
-    public class JsonWriterException : JsonException
+    internal class JsonWriterException : JsonException
     {
         /// <summary>
         /// Gets the path to the JSON where the error occurred.

--- a/src/Exceptionless/Newtonsoft.Json/Linq/CommentHandling.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/CommentHandling.cs
@@ -3,7 +3,7 @@ namespace Exceptionless.Json.Linq
     /// <summary>
     /// Specifies how JSON comments are handled when loading JSON.
     /// </summary>
-    public enum CommentHandling
+    internal enum CommentHandling
     {
         /// <summary>
         /// Ignore comments.
@@ -19,7 +19,7 @@ namespace Exceptionless.Json.Linq
     /// <summary>
     /// Specifies how line information is handled when loading JSON.
     /// </summary>
-    public enum LineInfoHandling
+    internal enum LineInfoHandling
     {
         /// <summary>
         /// Ignore line information.

--- a/src/Exceptionless/Newtonsoft.Json/Linq/Extensions.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/Extensions.cs
@@ -39,7 +39,7 @@ namespace Exceptionless.Json.Linq
     /// <summary>
     /// Contains the LINQ to JSON extension methods.
     /// </summary>
-    public static class Extensions
+    internal static class Extensions
     {
         /// <summary>
         /// Returns a collection of tokens that contains the ancestors of every token in the source collection.

--- a/src/Exceptionless/Newtonsoft.Json/Linq/IJEnumerable.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/IJEnumerable.cs
@@ -31,7 +31,7 @@ namespace Exceptionless.Json.Linq
     /// Represents a collection of <see cref="JToken"/> objects.
     /// </summary>
     /// <typeparam name="T">The type of token</typeparam>
-    public interface IJEnumerable<
+    internal interface IJEnumerable<
 #if !(NET20 || NET35)
         out
 #endif

--- a/src/Exceptionless/Newtonsoft.Json/Linq/JArray.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/JArray.cs
@@ -38,7 +38,7 @@ namespace Exceptionless.Json.Linq
     /// <example>
     ///   <code lang="cs" source="..\Src\Exceptionless.Json.Tests\Documentation\LinqToJsonTests.cs" region="LinqToJsonCreateParseArray" title="Parsing a JSON Array from Text" />
     /// </example>
-    public class JArray : JContainer, IList<JToken>
+    internal class JArray : JContainer, IList<JToken>
     {
         private readonly List<JToken> _values = new List<JToken>();
 

--- a/src/Exceptionless/Newtonsoft.Json/Linq/JConstructor.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/JConstructor.cs
@@ -34,7 +34,7 @@ namespace Exceptionless.Json.Linq
     /// <summary>
     /// Represents a JSON constructor.
     /// </summary>
-    public class JConstructor : JContainer
+    internal class JConstructor : JContainer
     {
         private string _name;
         private readonly List<JToken> _values = new List<JToken>();

--- a/src/Exceptionless/Newtonsoft.Json/Linq/JContainer.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/JContainer.cs
@@ -45,7 +45,7 @@ namespace Exceptionless.Json.Linq
     /// <summary>
     /// Represents a token that can contain other tokens.
     /// </summary>
-    public abstract class JContainer : JToken, IList<JToken>
+    internal abstract class JContainer : JToken, IList<JToken>
 #if !(DOTNET || PORTABLE || PORTABLE40 || NETSTANDARD1_0 || NETSTANDARD1_1 || NETSTANDARD1_2 || NETSTANDARD1_3 || NETSTANDARD1_4 || NETSTANDARD1_5)
         , ITypedList, IBindingList
 #endif

--- a/src/Exceptionless/Newtonsoft.Json/Linq/JEnumerable.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/JEnumerable.cs
@@ -39,7 +39,7 @@ namespace Exceptionless.Json.Linq
     /// Represents a collection of <see cref="JToken"/> objects.
     /// </summary>
     /// <typeparam name="T">The type of token</typeparam>
-    public struct JEnumerable<T> : IJEnumerable<T>, IEquatable<JEnumerable<T>> where T : JToken
+    internal struct JEnumerable<T> : IJEnumerable<T>, IEquatable<JEnumerable<T>> where T : JToken
     {
         /// <summary>
         /// An empty collection of <see cref="JToken"/> objects.

--- a/src/Exceptionless/Newtonsoft.Json/Linq/JObject.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/JObject.cs
@@ -52,7 +52,7 @@ namespace Exceptionless.Json.Linq
     /// <example>
     ///   <code lang="cs" source="..\Src\Exceptionless.Json.Tests\Documentation\LinqToJsonTests.cs" region="LinqToJsonCreateParse" title="Parsing a JSON Object from Text" />
     /// </example>
-    public class JObject : JContainer, IDictionary<string, JToken>, INotifyPropertyChanged
+    internal class JObject : JContainer, IDictionary<string, JToken>, INotifyPropertyChanged
 #if !(DOTNET || PORTABLE40 || PORTABLE || NETSTANDARD1_0 || NETSTANDARD1_1 || NETSTANDARD1_2 || NETSTANDARD1_3 || NETSTANDARD1_4 || NETSTANDARD1_5)
         , ICustomTypeDescriptor
 #endif

--- a/src/Exceptionless/Newtonsoft.Json/Linq/JProperty.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/JProperty.cs
@@ -35,7 +35,7 @@ namespace Exceptionless.Json.Linq
     /// <summary>
     /// Represents a JSON property.
     /// </summary>
-    public class JProperty : JContainer
+    internal class JProperty : JContainer
     {
         #region JPropertyList
         private class JPropertyList : IList<JToken>

--- a/src/Exceptionless/Newtonsoft.Json/Linq/JPropertyDescriptor.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/JPropertyDescriptor.cs
@@ -32,7 +32,7 @@ namespace Exceptionless.Json.Linq
     /// <summary>
     /// Represents a view of a <see cref="JProperty"/>.
     /// </summary>
-    public class JPropertyDescriptor : PropertyDescriptor
+    internal class JPropertyDescriptor : PropertyDescriptor
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="JPropertyDescriptor"/> class.

--- a/src/Exceptionless/Newtonsoft.Json/Linq/JRaw.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/JRaw.cs
@@ -31,7 +31,7 @@ namespace Exceptionless.Json.Linq
     /// <summary>
     /// Represents a raw JSON string.
     /// </summary>
-    public class JRaw : JValue
+    internal class JRaw : JValue
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="JRaw"/> class from another <see cref="JRaw"/> object.

--- a/src/Exceptionless/Newtonsoft.Json/Linq/JToken.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/JToken.cs
@@ -51,7 +51,7 @@ namespace Exceptionless.Json.Linq
     /// <summary>
     /// Represents an abstract JSON token.
     /// </summary>
-    public abstract class JToken : IJEnumerable<JToken>, IJsonLineInfo
+    internal abstract class JToken : IJEnumerable<JToken>, IJsonLineInfo
 #if !(DOTNET || PORTABLE40 || PORTABLE || NETSTANDARD1_0 || NETSTANDARD1_1 || NETSTANDARD1_2 || NETSTANDARD1_3 || NETSTANDARD1_4 || NETSTANDARD1_5)
         , ICloneable
 #endif
@@ -785,7 +785,7 @@ namespace Exceptionless.Json.Linq
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>
-        [CLSCompliant(false)]
+        
         public static explicit operator ushort(JToken value)
         {
             JValue v = EnsureValue(value);
@@ -809,7 +809,7 @@ namespace Exceptionless.Json.Linq
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>
-        [CLSCompliant(false)]
+        
         public static explicit operator char(JToken value)
         {
             JValue v = EnsureValue(value);
@@ -856,7 +856,7 @@ namespace Exceptionless.Json.Linq
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>
-        [CLSCompliant(false)]
+        
         public static explicit operator sbyte(JToken value)
         {
             JValue v = EnsureValue(value);
@@ -936,7 +936,7 @@ namespace Exceptionless.Json.Linq
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>
-        [CLSCompliant(false)]
+        
         public static explicit operator ushort?(JToken value)
         {
             if (value == null)
@@ -993,7 +993,7 @@ namespace Exceptionless.Json.Linq
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>
-        [CLSCompliant(false)]
+        
         public static explicit operator sbyte?(JToken value)
         {
             if (value == null)
@@ -1124,7 +1124,7 @@ namespace Exceptionless.Json.Linq
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>
-        [CLSCompliant(false)]
+        
         public static explicit operator uint?(JToken value)
         {
             if (value == null)
@@ -1153,7 +1153,7 @@ namespace Exceptionless.Json.Linq
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>
-        [CLSCompliant(false)]
+        
         public static explicit operator ulong?(JToken value)
         {
             if (value == null)
@@ -1264,7 +1264,7 @@ namespace Exceptionless.Json.Linq
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>
-        [CLSCompliant(false)]
+        
         public static explicit operator uint(JToken value)
         {
             JValue v = EnsureValue(value);
@@ -1288,7 +1288,7 @@ namespace Exceptionless.Json.Linq
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>
-        [CLSCompliant(false)]
+        
         public static explicit operator ulong(JToken value)
         {
             JValue v = EnsureValue(value);
@@ -1542,7 +1542,7 @@ namespace Exceptionless.Json.Linq
         /// </summary>
         /// <param name="value">The value to create a <see cref="JValue"/> from.</param>
         /// <returns>The <see cref="JValue"/> initialized with the specified value.</returns>
-        [CLSCompliant(false)]
+        
         public static implicit operator JToken(sbyte value)
         {
             return new JValue(value);
@@ -1553,7 +1553,7 @@ namespace Exceptionless.Json.Linq
         /// </summary>
         /// <param name="value">The value to create a <see cref="JValue"/> from.</param>
         /// <returns>The <see cref="JValue"/> initialized with the specified value.</returns>
-        [CLSCompliant(false)]
+        
         public static implicit operator JToken(sbyte? value)
         {
             return new JValue(value);
@@ -1626,7 +1626,7 @@ namespace Exceptionless.Json.Linq
         /// </summary>
         /// <param name="value">The value to create a <see cref="JValue"/> from.</param>
         /// <returns>The <see cref="JValue"/> initialized with the specified value.</returns>
-        [CLSCompliant(false)]
+        
         public static implicit operator JToken(short value)
         {
             return new JValue(value);
@@ -1637,7 +1637,7 @@ namespace Exceptionless.Json.Linq
         /// </summary>
         /// <param name="value">The value to create a <see cref="JValue"/> from.</param>
         /// <returns>The <see cref="JValue"/> initialized with the specified value.</returns>
-        [CLSCompliant(false)]
+        
         public static implicit operator JToken(ushort value)
         {
             return new JValue(value);
@@ -1708,7 +1708,7 @@ namespace Exceptionless.Json.Linq
         /// </summary>
         /// <param name="value">The value to create a <see cref="JValue"/> from.</param>
         /// <returns>The <see cref="JValue"/> initialized with the specified value.</returns>
-        [CLSCompliant(false)]
+        
         public static implicit operator JToken(short? value)
         {
             return new JValue(value);
@@ -1719,7 +1719,7 @@ namespace Exceptionless.Json.Linq
         /// </summary>
         /// <param name="value">The value to create a <see cref="JValue"/> from.</param>
         /// <returns>The <see cref="JValue"/> initialized with the specified value.</returns>
-        [CLSCompliant(false)]
+        
         public static implicit operator JToken(ushort? value)
         {
             return new JValue(value);
@@ -1730,7 +1730,7 @@ namespace Exceptionless.Json.Linq
         /// </summary>
         /// <param name="value">The value to create a <see cref="JValue"/> from.</param>
         /// <returns>The <see cref="JValue"/> initialized with the specified value.</returns>
-        [CLSCompliant(false)]
+        
         public static implicit operator JToken(uint? value)
         {
             return new JValue(value);
@@ -1741,7 +1741,7 @@ namespace Exceptionless.Json.Linq
         /// </summary>
         /// <param name="value">The value to create a <see cref="JValue"/> from.</param>
         /// <returns>The <see cref="JValue"/> initialized with the specified value.</returns>
-        [CLSCompliant(false)]
+        
         public static implicit operator JToken(ulong? value)
         {
             return new JValue(value);
@@ -1782,7 +1782,7 @@ namespace Exceptionless.Json.Linq
         /// </summary>
         /// <param name="value">The value to create a <see cref="JValue"/> from.</param>
         /// <returns>The <see cref="JValue"/> initialized with the specified value.</returns>
-        [CLSCompliant(false)]
+        
         public static implicit operator JToken(uint value)
         {
             return new JValue(value);
@@ -1793,7 +1793,7 @@ namespace Exceptionless.Json.Linq
         /// </summary>
         /// <param name="value">The value to create a <see cref="JValue"/> from.</param>
         /// <returns>The <see cref="JValue"/> initialized with the specified value.</returns>
-        [CLSCompliant(false)]
+        
         public static implicit operator JToken(ulong value)
         {
             return new JValue(value);

--- a/src/Exceptionless/Newtonsoft.Json/Linq/JTokenEqualityComparer.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/JTokenEqualityComparer.cs
@@ -30,7 +30,7 @@ namespace Exceptionless.Json.Linq
     /// <summary>
     /// Compares tokens to determine whether they are equal.
     /// </summary>
-    public class JTokenEqualityComparer : IEqualityComparer<JToken>
+    internal class JTokenEqualityComparer : IEqualityComparer<JToken>
     {
         /// <summary>
         /// Determines whether the specified objects are equal.

--- a/src/Exceptionless/Newtonsoft.Json/Linq/JTokenReader.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/JTokenReader.cs
@@ -31,7 +31,7 @@ namespace Exceptionless.Json.Linq
     /// <summary>
     /// Represents a reader that provides fast, non-cached, forward-only access to serialized JSON data.
     /// </summary>
-    public class JTokenReader : JsonReader, IJsonLineInfo
+    internal class JTokenReader : JsonReader, IJsonLineInfo
     {
         private readonly string _initialPath;
         private readonly JToken _root;

--- a/src/Exceptionless/Newtonsoft.Json/Linq/JTokenType.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/JTokenType.cs
@@ -28,7 +28,7 @@ namespace Exceptionless.Json.Linq
     /// <summary>
     /// Specifies the type of token.
     /// </summary>
-    public enum JTokenType
+    internal enum JTokenType
     {
         /// <summary>
         /// No token type has been set.

--- a/src/Exceptionless/Newtonsoft.Json/Linq/JTokenWriter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/JTokenWriter.cs
@@ -35,7 +35,7 @@ namespace Exceptionless.Json.Linq
     /// <summary>
     /// Represents a writer that provides a fast, non-cached, forward-only way of generating JSON data.
     /// </summary>
-    public class JTokenWriter : JsonWriter
+    internal class JTokenWriter : JsonWriter
     {
         private JContainer _token;
         private JContainer _parent;
@@ -296,7 +296,7 @@ namespace Exceptionless.Json.Linq
         /// Writes a <see cref="UInt32"/> value.
         /// </summary>
         /// <param name="value">The <see cref="UInt32"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public override void WriteValue(uint value)
         {
             base.WriteValue(value);
@@ -317,7 +317,7 @@ namespace Exceptionless.Json.Linq
         /// Writes a <see cref="UInt64"/> value.
         /// </summary>
         /// <param name="value">The <see cref="UInt64"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public override void WriteValue(ulong value)
         {
             base.WriteValue(value);
@@ -368,7 +368,7 @@ namespace Exceptionless.Json.Linq
         /// Writes a <see cref="UInt16"/> value.
         /// </summary>
         /// <param name="value">The <see cref="UInt16"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public override void WriteValue(ushort value)
         {
             base.WriteValue(value);
@@ -405,7 +405,7 @@ namespace Exceptionless.Json.Linq
         /// Writes a <see cref="SByte"/> value.
         /// </summary>
         /// <param name="value">The <see cref="SByte"/> value to write.</param>
-        [CLSCompliant(false)]
+        
         public override void WriteValue(sbyte value)
         {
             base.WriteValue(value);

--- a/src/Exceptionless/Newtonsoft.Json/Linq/JValue.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/JValue.cs
@@ -41,7 +41,7 @@ namespace Exceptionless.Json.Linq
     /// <summary>
     /// Represents a value in JSON (string, integer, date, etc).
     /// </summary>
-    public class JValue : JToken, IEquatable<JValue>, IFormattable, IComparable, IComparable<JValue>
+    internal class JValue : JToken, IEquatable<JValue>, IFormattable, IComparable, IComparable<JValue>
 #if !(PORTABLE || NETSTANDARD1_0 || NETSTANDARD1_1 || NETSTANDARD1_2)
         , IConvertible
 #endif
@@ -95,7 +95,7 @@ namespace Exceptionless.Json.Linq
         /// Initializes a new instance of the <see cref="JValue"/> class with the given value.
         /// </summary>
         /// <param name="value">The value.</param>
-        [CLSCompliant(false)]
+        
         public JValue(ulong value)
             : this(value, JTokenType.Integer)
         {

--- a/src/Exceptionless/Newtonsoft.Json/Linq/JsonLoadSettings.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/JsonLoadSettings.cs
@@ -5,7 +5,7 @@ namespace Exceptionless.Json.Linq
     /// <summary>
     /// Specifies the settings used when loading JSON.
     /// </summary>
-    public class JsonLoadSettings
+    internal class JsonLoadSettings
     {
         private CommentHandling _commentHandling;
         private LineInfoHandling _lineInfoHandling;

--- a/src/Exceptionless/Newtonsoft.Json/Linq/JsonMergeSettings.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/JsonMergeSettings.cs
@@ -5,7 +5,7 @@ namespace Exceptionless.Json.Linq
     /// <summary>
     /// Specifies the settings used when merging JSON.
     /// </summary>
-    public class JsonMergeSettings
+    internal class JsonMergeSettings
     {
         private MergeArrayHandling _mergeArrayHandling;
         private MergeNullValueHandling _mergeNullValueHandling;

--- a/src/Exceptionless/Newtonsoft.Json/Linq/MergeArrayHandling.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/MergeArrayHandling.cs
@@ -3,7 +3,7 @@ namespace Exceptionless.Json.Linq
     /// <summary>
     /// Specifies how JSON arrays are merged together.
     /// </summary>
-    public enum MergeArrayHandling
+    internal enum MergeArrayHandling
     {
         /// <summary>Concatenate arrays.</summary>
         Concat = 0,

--- a/src/Exceptionless/Newtonsoft.Json/Linq/MergeNullValueHandling.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Linq/MergeNullValueHandling.cs
@@ -6,7 +6,7 @@ namespace Exceptionless.Json.Linq
     /// Specifies how null value properties are merged.
     /// </summary>
     [Flags]
-    public enum MergeNullValueHandling
+    internal enum MergeNullValueHandling
     {
         /// <summary>
         /// The content's null value properties will be ignored during merging.

--- a/src/Exceptionless/Newtonsoft.Json/MemberSerialization.cs
+++ b/src/Exceptionless/Newtonsoft.Json/MemberSerialization.cs
@@ -32,7 +32,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Specifies the member serialization options for the <see cref="JsonSerializer"/>.
     /// </summary>
-    public enum MemberSerialization
+    internal enum MemberSerialization
     {
 #pragma warning disable 1584,1711,1572,1581,1580,1574
         /// <summary>

--- a/src/Exceptionless/Newtonsoft.Json/MetadataPropertyHandling.cs
+++ b/src/Exceptionless/Newtonsoft.Json/MetadataPropertyHandling.cs
@@ -32,7 +32,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Specifies metadata property handling options for the <see cref="JsonSerializer"/>.
     /// </summary>
-    public enum MetadataPropertyHandling
+    internal enum MetadataPropertyHandling
     {
         /// <summary>
         /// Read metadata properties located at the start of a JSON object.

--- a/src/Exceptionless/Newtonsoft.Json/MissingMemberHandling.cs
+++ b/src/Exceptionless/Newtonsoft.Json/MissingMemberHandling.cs
@@ -32,7 +32,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Specifies missing member handling options for the <see cref="JsonSerializer"/>.
     /// </summary>
-    public enum MissingMemberHandling
+    internal enum MissingMemberHandling
     {
         /// <summary>
         /// Ignore a missing member and do not attempt to deserialize it.

--- a/src/Exceptionless/Newtonsoft.Json/NullValueHandling.cs
+++ b/src/Exceptionless/Newtonsoft.Json/NullValueHandling.cs
@@ -32,7 +32,7 @@ namespace Exceptionless.Json
     ///   <code lang="cs" source="..\Src\Exceptionless.Json.Tests\Documentation\SerializationTests.cs" region="ReducingSerializedJsonSizeNullValueHandlingObject" title="NullValueHandling Class" />
     ///   <code lang="cs" source="..\Src\Exceptionless.Json.Tests\Documentation\SerializationTests.cs" region="ReducingSerializedJsonSizeNullValueHandlingExample" title="NullValueHandling Ignore Example" />
     /// </example>
-    public enum NullValueHandling
+    internal enum NullValueHandling
     {
         /// <summary>
         /// Include null values when serializing and deserializing objects.

--- a/src/Exceptionless/Newtonsoft.Json/ObjectCreationHandling.cs
+++ b/src/Exceptionless/Newtonsoft.Json/ObjectCreationHandling.cs
@@ -28,7 +28,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Specifies how object creation is handled by the <see cref="JsonSerializer"/>.
     /// </summary>
-    public enum ObjectCreationHandling
+    internal enum ObjectCreationHandling
     {
         /// <summary>
         /// Reuse existing objects, create new objects when needed.

--- a/src/Exceptionless/Newtonsoft.Json/PreserveReferencesHandling.cs
+++ b/src/Exceptionless/Newtonsoft.Json/PreserveReferencesHandling.cs
@@ -37,7 +37,7 @@ namespace Exceptionless.Json
     ///   <code lang="cs" source="..\Src\Exceptionless.Json.Tests\Documentation\SerializationTests.cs" region="PreservingObjectReferencesOn" title="Preserve Object References" />       
     /// </example>
     [Flags]
-    public enum PreserveReferencesHandling
+    internal enum PreserveReferencesHandling
     {
         /// <summary>
         /// Do not preserve references when serializing types.

--- a/src/Exceptionless/Newtonsoft.Json/ReferenceLoopHandling.cs
+++ b/src/Exceptionless/Newtonsoft.Json/ReferenceLoopHandling.cs
@@ -32,7 +32,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Specifies reference loop handling options for the <see cref="JsonSerializer"/>.
     /// </summary>
-    public enum ReferenceLoopHandling
+    internal enum ReferenceLoopHandling
     {
         /// <summary>
         /// Throw a <see cref="JsonSerializationException"/> when a loop is encountered.

--- a/src/Exceptionless/Newtonsoft.Json/Required.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Required.cs
@@ -28,7 +28,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Indicating whether a property is required.
     /// </summary>
-    public enum Required
+    internal enum Required
     {
         /// <summary>
         /// The property is not required. The default state.

--- a/src/Exceptionless/Newtonsoft.Json/Schema/Extensions.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Schema/Extensions.cs
@@ -39,7 +39,7 @@ namespace Exceptionless.Json.Schema
     /// </note>
     /// </summary>
     [Obsolete("JSON Schema validation has been moved to its own package. See http://www.newtonsoft.com/jsonschema for more details.")]
-    public static class Extensions
+    internal static class Extensions
     {
         /// <summary>
         /// <para>

--- a/src/Exceptionless/Newtonsoft.Json/Schema/JsonSchema.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Schema/JsonSchema.cs
@@ -41,7 +41,7 @@ namespace Exceptionless.Json.Schema
     /// </note>
     /// </summary>
     [Obsolete("JSON Schema validation has been moved to its own package. See http://www.newtonsoft.com/jsonschema for more details.")]
-    public class JsonSchema
+    internal class JsonSchema
     {
         /// <summary>
         /// Gets or sets the id.

--- a/src/Exceptionless/Newtonsoft.Json/Schema/JsonSchemaException.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Schema/JsonSchemaException.cs
@@ -40,7 +40,7 @@ namespace Exceptionless.Json.Schema
     [Serializable]
 #endif
     [Obsolete("JSON Schema validation has been moved to its own package. See http://www.newtonsoft.com/jsonschema for more details.")]
-    public class JsonSchemaException : JsonException
+    internal class JsonSchemaException : JsonException
     {
         /// <summary>
         /// Gets the line number indicating where the error occurred.

--- a/src/Exceptionless/Newtonsoft.Json/Schema/JsonSchemaGenerator.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Schema/JsonSchemaGenerator.cs
@@ -49,7 +49,7 @@ namespace Exceptionless.Json.Schema
     /// </note>
     /// </summary>
     [Obsolete("JSON Schema validation has been moved to its own package. See http://www.newtonsoft.com/jsonschema for more details.")]
-    public class JsonSchemaGenerator
+    internal class JsonSchemaGenerator
     {
         /// <summary>
         /// Gets or sets how undefined schemas are handled by the serializer.

--- a/src/Exceptionless/Newtonsoft.Json/Schema/JsonSchemaResolver.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Schema/JsonSchemaResolver.cs
@@ -43,7 +43,7 @@ namespace Exceptionless.Json.Schema
     /// </note>
     /// </summary>
     [Obsolete("JSON Schema validation has been moved to its own package. See http://www.newtonsoft.com/jsonschema for more details.")]
-    public class JsonSchemaResolver
+    internal class JsonSchemaResolver
     {
         /// <summary>
         /// Gets or sets the loaded schemas.

--- a/src/Exceptionless/Newtonsoft.Json/Schema/JsonSchemaType.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Schema/JsonSchemaType.cs
@@ -37,7 +37,7 @@ namespace Exceptionless.Json.Schema
     /// </summary>
     [Flags]
     [Obsolete("JSON Schema validation has been moved to its own package. See http://www.newtonsoft.com/jsonschema for more details.")]
-    public enum JsonSchemaType
+    internal enum JsonSchemaType
     {
         /// <summary>
         /// No type specified.

--- a/src/Exceptionless/Newtonsoft.Json/Schema/UndefinedSchemaIdHandling.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Schema/UndefinedSchemaIdHandling.cs
@@ -36,7 +36,7 @@ namespace Exceptionless.Json.Schema
     /// </note>
     /// </summary>
     [Obsolete("JSON Schema validation has been moved to its own package. See http://www.newtonsoft.com/jsonschema for more details.")]
-    public enum UndefinedSchemaIdHandling
+    internal enum UndefinedSchemaIdHandling
     {
         /// <summary>
         /// Do not infer a schema Id.

--- a/src/Exceptionless/Newtonsoft.Json/Schema/ValidationEventArgs.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Schema/ValidationEventArgs.cs
@@ -37,7 +37,7 @@ namespace Exceptionless.Json.Schema
     /// </note>
     /// </summary>
     [Obsolete("JSON Schema validation has been moved to its own package. See http://www.newtonsoft.com/jsonschema for more details.")]
-    public class ValidationEventArgs : EventArgs
+    internal class ValidationEventArgs : EventArgs
     {
         private readonly JsonSchemaException _ex;
 

--- a/src/Exceptionless/Newtonsoft.Json/Schema/ValidationEventHandler.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Schema/ValidationEventHandler.cs
@@ -36,5 +36,5 @@ namespace Exceptionless.Json.Schema
     /// </note>
     /// </summary>
     [Obsolete("JSON Schema validation has been moved to its own package. See http://www.newtonsoft.com/jsonschema for more details.")]
-    public delegate void ValidationEventHandler(object sender, ValidationEventArgs e);
+    internal delegate void ValidationEventHandler(object sender, ValidationEventArgs e);
 }

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/CamelCasePropertyNamesContractResolver.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/CamelCasePropertyNamesContractResolver.cs
@@ -31,7 +31,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Resolves member mappings for a type, camel casing property names.
     /// </summary>
-    public class CamelCasePropertyNamesContractResolver : DefaultContractResolver
+    internal class CamelCasePropertyNamesContractResolver : DefaultContractResolver
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CamelCasePropertyNamesContractResolver"/> class.

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -97,7 +97,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Used by <see cref="JsonSerializer"/> to resolves a <see cref="JsonContract"/> for a given <see cref="System.Type"/>.
     /// </summary>
-    public class DefaultContractResolver : IContractResolver
+    internal class DefaultContractResolver : IContractResolver
     {
 #pragma warning disable 612,618
         private static readonly IContractResolver _instance = new DefaultContractResolver(true);
@@ -586,7 +586,7 @@ namespace Exceptionless.Json.Serialization
         internal class EnumerableDictionaryWrapper<TEnumeratorKey, TEnumeratorValue> : IEnumerable<KeyValuePair<object, object>>
         {
             private readonly IEnumerable<KeyValuePair<TEnumeratorKey, TEnumeratorValue>> _e;
-
+            
             public EnumerableDictionaryWrapper(IEnumerable<KeyValuePair<TEnumeratorKey, TEnumeratorValue>> e)
             {
                 ValidationUtils.ArgumentNotNull(e, nameof(e));

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -1438,7 +1438,7 @@ namespace Exceptionless.Json.Serialization
             property.HasMemberAttribute = hasMemberAttribute;
 
             bool hasJsonIgnoreAttribute =
-                JsonTypeReflector.GetAttribute<JsonIgnoreAttribute>(attributeProvider) != null
+                JsonTypeReflector.GetAttribute<DataMemberIgnoreAttribute>(attributeProvider) != null
                     // automatically ignore extension data dictionary property if it is public
                 || JsonTypeReflector.GetAttribute<JsonExtensionDataAttribute>(attributeProvider) != null
 #if !(DOTNET || PORTABLE40 || PORTABLE || NETSTANDARD1_0 || NETSTANDARD1_1 || NETSTANDARD1_2 || NETSTANDARD1_3 || NETSTANDARD1_4 || NETSTANDARD1_5)

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/DefaultSerializationBinder.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/DefaultSerializationBinder.cs
@@ -34,7 +34,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// The default serialization binder used when resolving and loading classes from type names.
     /// </summary>
-    public class DefaultSerializationBinder : SerializationBinder
+    internal class DefaultSerializationBinder : SerializationBinder
     {
         internal static readonly DefaultSerializationBinder Instance = new DefaultSerializationBinder();
 

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/DiagnosticsTraceWriter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/DiagnosticsTraceWriter.cs
@@ -8,7 +8,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Represents a trace writer that writes to the application's <see cref="TraceListener"/> instances.
     /// </summary>
-    public class DiagnosticsTraceWriter : ITraceWriter
+    internal class DiagnosticsTraceWriter : ITraceWriter
     {
         /// <summary>
         /// Gets the <see cref="TraceLevel"/> that will be used to filter the trace messages passed to the writer.

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/DynamicValueProvider.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/DynamicValueProvider.cs
@@ -39,7 +39,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Get and set values for a <see cref="MemberInfo"/> using dynamic methods.
     /// </summary>
-    public class DynamicValueProvider : IValueProvider
+    internal class DynamicValueProvider : IValueProvider
     {
         private readonly MemberInfo _memberInfo;
         private Func<object, object> _getter;

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/ErrorContext.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/ErrorContext.cs
@@ -30,7 +30,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Provides information surrounding an error.
     /// </summary>
-    public class ErrorContext
+    internal class ErrorContext
     {
         internal ErrorContext(object originalObject, object member, string path, Exception error)
         {

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/ErrorEventArgs.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/ErrorEventArgs.cs
@@ -30,7 +30,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Provides data for the Error event.
     /// </summary>
-    public class ErrorEventArgs : EventArgs
+    internal class ErrorEventArgs : EventArgs
     {
         /// <summary>
         /// Gets the current object the error event is being raised against.

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/ExpressionValueProvider.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/ExpressionValueProvider.cs
@@ -39,7 +39,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Get and set values for a <see cref="MemberInfo"/> using dynamic methods.
     /// </summary>
-    public class ExpressionValueProvider : IValueProvider
+    internal class ExpressionValueProvider : IValueProvider
     {
         private readonly MemberInfo _memberInfo;
         private Func<object, object> _getter;

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/IAttributeProvider.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/IAttributeProvider.cs
@@ -31,7 +31,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Provides methods to get attributes.
     /// </summary>
-    public interface IAttributeProvider
+    internal interface IAttributeProvider
     {
         /// <summary>
         /// Returns a collection of all of the attributes, or an empty collection if there are no attributes.

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/IContractResolver.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/IContractResolver.cs
@@ -34,7 +34,7 @@ namespace Exceptionless.Json.Serialization
     ///   <code lang="cs" source="..\Src\Exceptionless.Json.Tests\Documentation\SerializationTests.cs" region="ReducingSerializedJsonSizeContractResolverObject" title="IContractResolver Class" />
     ///   <code lang="cs" source="..\Src\Exceptionless.Json.Tests\Documentation\SerializationTests.cs" region="ReducingSerializedJsonSizeContractResolverExample" title="IContractResolver Example" />
     /// </example>
-    public interface IContractResolver
+    internal interface IContractResolver
     {
         /// <summary>
         /// Resolves the contract for a given type.

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/IReferenceResolver.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/IReferenceResolver.cs
@@ -28,7 +28,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Used to resolve references when serializing and deserializing JSON by the <see cref="JsonSerializer"/>.
     /// </summary>
-    public interface IReferenceResolver
+    internal interface IReferenceResolver
     {
         /// <summary>
         /// Resolves a reference to its object.

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/ITraceWriter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/ITraceWriter.cs
@@ -7,7 +7,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Represents a trace writer.
     /// </summary>
-    public interface ITraceWriter
+    internal interface ITraceWriter
     {
         /// <summary>
         /// Gets the <see cref="TraceLevel"/> that will be used to filter the trace messages passed to the writer.

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/IValueProvider.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/IValueProvider.cs
@@ -28,7 +28,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Provides methods to get and set values.
     /// </summary>
-    public interface IValueProvider
+    internal interface IValueProvider
     {
         /// <summary>
         /// Sets the value.

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/JsonArrayContract.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/JsonArrayContract.cs
@@ -43,7 +43,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Contract details for a <see cref="System.Type"/> used by the <see cref="JsonSerializer"/>.
     /// </summary>
-    public class JsonArrayContract : JsonContainerContract
+    internal class JsonArrayContract : JsonContainerContract
     {
         /// <summary>
         /// Gets the <see cref="System.Type"/> of the collection items.

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/JsonContainerContract.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/JsonContainerContract.cs
@@ -40,7 +40,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Contract details for a <see cref="System.Type"/> used by the <see cref="JsonSerializer"/>.
     /// </summary>
-    public class JsonContainerContract : JsonContract
+    internal class JsonContainerContract : JsonContract
     {
         private JsonContract _itemContract;
         private JsonContract _finalItemContract;

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/JsonContract.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/JsonContract.cs
@@ -51,7 +51,7 @@ namespace Exceptionless.Json.Serialization
     /// </summary>
     /// <param name="o">The object that raised the callback event.</param>
     /// <param name="context">The streaming context.</param>
-    public delegate void SerializationCallback(object o, StreamingContext context);
+    internal delegate void SerializationCallback(object o, StreamingContext context);
 
     /// <summary>
     /// Handles <see cref="JsonSerializer"/> serialization error callback events.
@@ -59,7 +59,7 @@ namespace Exceptionless.Json.Serialization
     /// <param name="o">The object that raised the callback event.</param>
     /// <param name="context">The streaming context.</param>
     /// <param name="errorContext">The error context.</param>
-    public delegate void SerializationErrorCallback(object o, StreamingContext context, ErrorContext errorContext);
+    internal delegate void SerializationErrorCallback(object o, StreamingContext context, ErrorContext errorContext);
 
     /// <summary>
     /// Sets extension data for an object during deserialization.
@@ -67,18 +67,18 @@ namespace Exceptionless.Json.Serialization
     /// <param name="o">The object to set extension data on.</param>
     /// <param name="key">The extension data key.</param>
     /// <param name="value">The extension data value.</param>
-    public delegate void ExtensionDataSetter(object o, string key, object value);
+    internal delegate void ExtensionDataSetter(object o, string key, object value);
 
     /// <summary>
     /// Gets extension data for an object during serialization.
     /// </summary>
     /// <param name="o">The object to set extension data on.</param>
-    public delegate IEnumerable<KeyValuePair<object, object>> ExtensionDataGetter(object o);
+    internal delegate IEnumerable<KeyValuePair<object, object>> ExtensionDataGetter(object o);
 
     /// <summary>
     /// Contract details for a <see cref="System.Type"/> used by the <see cref="JsonSerializer"/>.
     /// </summary>
-    public abstract class JsonContract
+    internal abstract class JsonContract
     {
         internal bool IsNullable;
         internal bool IsConvertable;

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/JsonDictionaryContract.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/JsonDictionaryContract.cs
@@ -39,7 +39,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Contract details for a <see cref="System.Type"/> used by the <see cref="JsonSerializer"/>.
     /// </summary>
-    public class JsonDictionaryContract : JsonContainerContract
+    internal class JsonDictionaryContract : JsonContainerContract
     {
         /// <summary>
         /// Gets or sets the property name resolver.

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/JsonDynamicContract.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/JsonDynamicContract.cs
@@ -37,7 +37,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Contract details for a <see cref="Type"/> used by the <see cref="JsonSerializer"/>.
     /// </summary>
-    public class JsonDynamicContract : JsonContainerContract
+    internal class JsonDynamicContract : JsonContainerContract
     {
         /// <summary>
         /// Gets the object's properties.

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/JsonISerializableContract.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/JsonISerializableContract.cs
@@ -32,7 +32,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Contract details for a <see cref="Type"/> used by the <see cref="JsonSerializer"/>.
     /// </summary>
-    public class JsonISerializableContract : JsonContainerContract
+    internal class JsonISerializableContract : JsonContainerContract
     {
         /// <summary>
         /// Gets or sets the ISerializable object constructor.

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/JsonLinqContract.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/JsonLinqContract.cs
@@ -30,7 +30,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Contract details for a <see cref="Type"/> used by the <see cref="JsonSerializer"/>.
     /// </summary>
-    public class JsonLinqContract : JsonContract
+    internal class JsonLinqContract : JsonContract
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonLinqContract"/> class.

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/JsonObjectContract.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/JsonObjectContract.cs
@@ -36,7 +36,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Contract details for a <see cref="System.Type"/> used by the <see cref="JsonSerializer"/>.
     /// </summary>
-    public class JsonObjectContract : JsonContainerContract
+    internal class JsonObjectContract : JsonContainerContract
     {
         /// <summary>
         /// Gets or sets the object member serialization.

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/JsonPrimitiveContract.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/JsonPrimitiveContract.cs
@@ -32,7 +32,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Contract details for a <see cref="Type"/> used by the <see cref="JsonSerializer"/>.
     /// </summary>
-    public class JsonPrimitiveContract : JsonContract
+    internal class JsonPrimitiveContract : JsonContract
     {
         internal PrimitiveTypeCode TypeCode { get; set; }
 

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/JsonProperty.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/JsonProperty.cs
@@ -36,7 +36,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Maps a JSON property to a .NET member or constructor parameter.
     /// </summary>
-    public class JsonProperty
+    internal class JsonProperty
     {
         internal Required? _required;
         internal bool _hasExplicitDefaultValue;

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/JsonPropertyCollection.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/JsonPropertyCollection.cs
@@ -35,7 +35,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// A collection of <see cref="JsonProperty"/> objects.
     /// </summary>
-    public class JsonPropertyCollection : KeyedCollection<string, JsonProperty>
+    internal class JsonPropertyCollection : KeyedCollection<string, JsonProperty>
     {
         private readonly Type _type;
         private readonly List<JsonProperty> _list;

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/JsonStringContract.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/JsonStringContract.cs
@@ -30,7 +30,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Contract details for a <see cref="Type"/> used by the <see cref="JsonSerializer"/>.
     /// </summary>
-    public class JsonStringContract : JsonPrimitiveContract
+    internal class JsonStringContract : JsonPrimitiveContract
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonStringContract"/> class.

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/MemoryTraceWriter.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/MemoryTraceWriter.cs
@@ -10,7 +10,7 @@ namespace Exceptionless.Json.Serialization
     /// Represents a trace writer that writes to memory. When the trace message limit is
     /// reached then old trace messages will be removed as new messages are added.
     /// </summary>
-    public class MemoryTraceWriter : ITraceWriter
+    internal class MemoryTraceWriter : ITraceWriter
     {
         private readonly Queue<string> _traceMessages;
 

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/OnErrorAttribute.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/OnErrorAttribute.cs
@@ -31,7 +31,7 @@ namespace Exceptionless.Json.Serialization
     /// When applied to a method, specifies that the method is called when an error occurs serializing an object.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, Inherited = false)]
-    public sealed class OnErrorAttribute : Attribute
+    internal sealed class OnErrorAttribute : Attribute
     {
     }
 }

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/ReflectionAttributeProvider.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/ReflectionAttributeProvider.cs
@@ -33,7 +33,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Provides methods to get attributes from a <see cref="System.Type"/>, <see cref="MemberInfo"/>, <see cref="ParameterInfo"/> or <see cref="Assembly"/>.
     /// </summary>
-    public class ReflectionAttributeProvider : IAttributeProvider
+    internal class ReflectionAttributeProvider : IAttributeProvider
     {
         private readonly object _attributeProvider;
 

--- a/src/Exceptionless/Newtonsoft.Json/Serialization/ReflectionValueProvider.cs
+++ b/src/Exceptionless/Newtonsoft.Json/Serialization/ReflectionValueProvider.cs
@@ -33,7 +33,7 @@ namespace Exceptionless.Json.Serialization
     /// <summary>
     /// Get and set values for a <see cref="MemberInfo"/> using reflection.
     /// </summary>
-    public class ReflectionValueProvider : IValueProvider
+    internal class ReflectionValueProvider : IValueProvider
     {
         private readonly MemberInfo _memberInfo;
 

--- a/src/Exceptionless/Newtonsoft.Json/SerializationBinder.cs
+++ b/src/Exceptionless/Newtonsoft.Json/SerializationBinder.cs
@@ -8,7 +8,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Allows users to control class loading and mandate what class to load.
     /// </summary>
-    public abstract class SerializationBinder
+    internal abstract class SerializationBinder
     {
         /// <summary>
         /// When overridden in a derived class, controls the binding of a serialized object to a type.

--- a/src/Exceptionless/Newtonsoft.Json/StringEscapeHandling.cs
+++ b/src/Exceptionless/Newtonsoft.Json/StringEscapeHandling.cs
@@ -28,7 +28,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Specifies how strings are escaped when writing JSON text.
     /// </summary>
-    public enum StringEscapeHandling
+    internal enum StringEscapeHandling
     {
         /// <summary>
         /// Only control characters (e.g. newline) are escaped.

--- a/src/Exceptionless/Newtonsoft.Json/TraceLevel.cs
+++ b/src/Exceptionless/Newtonsoft.Json/TraceLevel.cs
@@ -7,7 +7,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Specifies what messages to output for the <see cref="ITraceWriter"/> class.
     /// </summary>
-    public enum TraceLevel
+    internal enum TraceLevel
     {
         /// <summary>
         /// Output no tracing and debugging messages.

--- a/src/Exceptionless/Newtonsoft.Json/TypeNameHandling.cs
+++ b/src/Exceptionless/Newtonsoft.Json/TypeNameHandling.cs
@@ -37,7 +37,7 @@ namespace Exceptionless.Json
     /// when deserializing with a value other than <c>TypeNameHandling.None</c>.
     /// </remarks>
     [Flags]
-    public enum TypeNameHandling
+    internal enum TypeNameHandling
     {
         /// <summary>
         /// Do not include the .NET type name when serializing types.

--- a/src/Exceptionless/Newtonsoft.Json/WriteState.cs
+++ b/src/Exceptionless/Newtonsoft.Json/WriteState.cs
@@ -30,7 +30,7 @@ namespace Exceptionless.Json
     /// <summary>
     /// Specifies the state of the <see cref="JsonWriter"/>.
     /// </summary>
-    public enum WriteState
+    internal enum WriteState
     {
         /// <summary>
         /// An exception has been thrown, which has left the <see cref="JsonWriter"/> in an invalid state.


### PR DESCRIPTION
Hello @ejsmith  @niemyjski , 

I think we have all realized the problems(#165)  about that the Json.NET is `public`. I also encountered these problems in my project. This PR is used to fix this problem.

This PR contains the following modifications:

* Change Newtonsoft.Json to internal
* Rename `JsonIgnoreAttribute` to `DataMemberIgnoreAttribute`
* Make `DataMemberIgnoreAttribute` access level to `public`

Related issues :  #165
