### PR TITLE
Recording exception details in logs to identify issues easier.

### DIFF
--- a/src/Exceptionless/ExceptionlessClient.cs
+++ b/src/Exceptionless/ExceptionlessClient.cs
@@ -112,7 +112,7 @@ namespace Exceptionless {
             try {
                 var response = _submissionClient.Value.PostUserDescription(referenceId, new UserDescription(email, description), Configuration, Configuration.Resolver.GetJsonSerializer());
                 if (!response.Success)
-                    _log.Value.FormattedError(typeof(ExceptionlessClient), "Failed to submit user email and description for event '{0}': {1} {2}", referenceId, response.StatusCode, response.Message);
+                    _log.Value.FormattedError(typeof(ExceptionlessClient), response.Exception, "Failed to submit user email and description for event '{0}': {1} {2}", referenceId, response.StatusCode, response.Message);
 
                 return response.Success;
             } catch (Exception ex) {

--- a/src/Exceptionless/Queue/DefaultEventQueue.cs
+++ b/src/Exceptionless/Queue/DefaultEventQueue.cs
@@ -109,7 +109,9 @@ namespace Exceptionless.Queue {
                                 _log.Error(typeof(DefaultEventQueue), "Event submission discarded for being too large. The event will not be submitted.");
                             }
                         } else if (!response.Success) {
-                            _log.Error(typeof(DefaultEventQueue), String.Concat("An error occurred while submitting events: ", response.Message));
+                            _log.Error(typeof(DefaultEventQueue), response.Exception, 
+                                String.IsNullOrEmpty(response.Message) ? "An error occurred while submitting events." : 
+                                String.Concat("An error occurred while submitting events: ", response.Message));
                             SuspendProcessing();
                             deleteBatch = false;
                         }

--- a/src/Exceptionless/Submission/DefaultSubmissionClient.cs
+++ b/src/Exceptionless/Submission/DefaultSubmissionClient.cs
@@ -43,7 +43,7 @@ namespace Exceptionless.Submission {
                 _client.Value.AddAuthorizationHeader(config.ApiKey);
                 response = _client.Value.PostAsync(url, content).ConfigureAwait(false).GetAwaiter().GetResult();
             } catch (Exception ex) {
-                return new SubmissionResponse(500, message: ex.Message);
+                return new SubmissionResponse(500, exception: ex);
             }
             
             int settingsVersion;
@@ -71,7 +71,7 @@ namespace Exceptionless.Submission {
                 _client.Value.AddAuthorizationHeader(config.ApiKey);
                 response = _client.Value.PostAsync(url, content).ConfigureAwait(false).GetAwaiter().GetResult();
             } catch (Exception ex) {
-                return new SubmissionResponse(500, message: ex.Message);
+                return new SubmissionResponse(500, exception: ex);
             }
 
             int settingsVersion;

--- a/src/Exceptionless/Submission/SubmissionResponse.cs
+++ b/src/Exceptionless/Submission/SubmissionResponse.cs
@@ -3,7 +3,7 @@ using System.Net;
 
 namespace Exceptionless.Submission {
     public class SubmissionResponse {
-        public SubmissionResponse(int statusCode, string message = null) {
+        public SubmissionResponse(int statusCode, string message = null, Exception exception = null) {
             StatusCode = statusCode;
             Message = message;
 
@@ -14,6 +14,7 @@ namespace Exceptionless.Submission {
             UnableToAuthenticate = (HttpStatusCode)statusCode == HttpStatusCode.Unauthorized || (HttpStatusCode)statusCode == HttpStatusCode.Forbidden;
             NotFound = (HttpStatusCode)statusCode == HttpStatusCode.NotFound;
             RequestEntityTooLarge = (HttpStatusCode)statusCode == HttpStatusCode.RequestEntityTooLarge;
+            Exception = exception;
         }
 
         public bool Success { get; private set; }
@@ -26,5 +27,7 @@ namespace Exceptionless.Submission {
 
         public int StatusCode { get; private set; }
         public string Message { get; private set; }
+
+        public Exception Exception { get; private set; }
     }
 }


### PR DESCRIPTION
Recently we have encountered an error which cannot be identified. Since the logging information is not enough.
![企业微信截图_15525849737512](https://user-images.githubusercontent.com/2819989/54406440-21e43500-4715-11e9-9c7f-3043132cc1c8.png)

The changes is to record much more details of the error while submitting events.