### PR TITLE
fix Startup failed while Assembly.GetCallingAssembly not supported

### DIFF
--- a/src/Exceptionless/Extensions/ExceptionlessConfigurationExtensions.cs
+++ b/src/Exceptionless/Extensions/ExceptionlessConfigurationExtensions.cs
@@ -258,7 +258,19 @@ namespace Exceptionless {
 #if NETSTANDARD1_5
                 config.ReadFromAttributes(Assembly.GetEntryAssembly());
 #elif NET45 || NETSTANDARD2_0
-                config.ReadFromAttributes(Assembly.GetEntryAssembly(), Assembly.GetCallingAssembly());
+                Assembly callingAssembly;
+                try {
+                    callingAssembly = Assembly.GetCallingAssembly();
+                }
+                catch (PlatformNotSupportedException) {
+                    callingAssembly = null;
+                }
+
+                if (callingAssembly == null) {
+                    config.ReadFromAttributes(Assembly.GetEntryAssembly());
+                } else {
+                    config.ReadFromAttributes(Assembly.GetEntryAssembly(), callingAssembly);
+                }
 #endif
             } else {
                 config.ReadFromAttributes(configAttributesAssemblies);

--- a/src/Exceptionless/Extensions/ExceptionlessConfigurationExtensions.cs
+++ b/src/Exceptionless/Extensions/ExceptionlessConfigurationExtensions.cs
@@ -266,11 +266,7 @@ namespace Exceptionless {
                     callingAssembly = null;
                 }
 
-                if (callingAssembly == null) {
-                    config.ReadFromAttributes(Assembly.GetEntryAssembly());
-                } else {
-                    config.ReadFromAttributes(Assembly.GetEntryAssembly(), callingAssembly);
-                }
+                config.ReadFromAttributes(Assembly.GetEntryAssembly(), callingAssembly);
 #endif
             } else {
                 config.ReadFromAttributes(configAttributesAssemblies);


### PR DESCRIPTION
fix #218 