### PR TITLE
Shrink SubmissionResponse

### DIFF
--- a/src/Exceptionless/Submission/SubmissionResponse.cs
+++ b/src/Exceptionless/Submission/SubmissionResponse.cs
@@ -3,31 +3,26 @@ using System.Net;
 
 namespace Exceptionless.Submission {
     public class SubmissionResponse {
+        internal static readonly SubmissionResponse Ok200 = new(200, "OK");
+
         public SubmissionResponse(int statusCode, string message = null, Exception exception = null) {
             StatusCode = statusCode;
             Message = message;
 
-            Success = statusCode >= 200 && statusCode <= 299;
-            BadRequest = (HttpStatusCode)statusCode == HttpStatusCode.BadRequest;
-            ServiceUnavailable = (HttpStatusCode)statusCode == HttpStatusCode.ServiceUnavailable;
-            PaymentRequired = (HttpStatusCode)statusCode == HttpStatusCode.PaymentRequired;
-            UnableToAuthenticate = (HttpStatusCode)statusCode == HttpStatusCode.Unauthorized || (HttpStatusCode)statusCode == HttpStatusCode.Forbidden;
-            NotFound = (HttpStatusCode)statusCode == HttpStatusCode.NotFound;
-            RequestEntityTooLarge = (HttpStatusCode)statusCode == HttpStatusCode.RequestEntityTooLarge;
             Exception = exception;
         }
 
-        public bool Success { get; private set; }
-        public bool BadRequest { get; private set; }
-        public bool ServiceUnavailable { get; private set; }
-        public bool PaymentRequired { get; private set; }
-        public bool UnableToAuthenticate { get; private set; }
-        public bool NotFound { get; private set; }
-        public bool RequestEntityTooLarge { get; private set; }
+        public bool Success => StatusCode >= 200 && StatusCode <= 299;
+        public bool BadRequest => (HttpStatusCode)StatusCode == HttpStatusCode.BadRequest;
+        public bool ServiceUnavailable => (HttpStatusCode)StatusCode == HttpStatusCode.ServiceUnavailable;
+        public bool PaymentRequired => (HttpStatusCode)StatusCode == HttpStatusCode.PaymentRequired;
+        public bool UnableToAuthenticate => (HttpStatusCode)StatusCode == HttpStatusCode.Unauthorized || (HttpStatusCode)StatusCode == HttpStatusCode.Forbidden;
+        public bool NotFound => (HttpStatusCode)StatusCode == HttpStatusCode.NotFound;
+        public bool RequestEntityTooLarge => (HttpStatusCode)StatusCode == HttpStatusCode.RequestEntityTooLarge;
 
-        public int StatusCode { get; private set; }
-        public string Message { get; private set; }
+        public int StatusCode { get; }
+        public string Message { get; }
 
-        public Exception Exception { get; private set; }
+        public Exception Exception { get; }
     }
 }


### PR DESCRIPTION
Inspecting with [ObjectLayoutInspector](https://www.nuget.org/packages/ObjectLayoutInspector/) `TypeLayout.PrintLayout<SubmissionResponse>()`

Pre
```
Type layout for 'SubmissionResponse'
Size: 32 bytes. Paddings: 5 bytes (%15 of empty space)
|================================================================|
| Object Header (8 bytes)                                        |
|----------------------------------------------------------------|
| Method Table Ptr (8 bytes)                                     |
|================================================================|
|   0-7: String <Message>k__BackingField (8 bytes)               |
|----------------------------------------------------------------|
|  8-15: Exception <Exception>k__BackingField (8 bytes)          |
|----------------------------------------------------------------|
| 16-19: Int32 <StatusCode>k__BackingField (4 bytes)             |
|----------------------------------------------------------------|
|    20: Boolean <Success>k__BackingField (1 byte)               |
|----------------------------------------------------------------|
|    21: Boolean <BadRequest>k__BackingField (1 byte)            |
|----------------------------------------------------------------|
|    22: Boolean <ServiceUnavailable>k__BackingField (1 byte)    |
|----------------------------------------------------------------|
|    23: Boolean <PaymentRequired>k__BackingField (1 byte)       |
|----------------------------------------------------------------|
|    24: Boolean <UnableToAuthenticate>k__BackingField (1 byte)  |
|----------------------------------------------------------------|
|    25: Boolean <NotFound>k__BackingField (1 byte)              |
|----------------------------------------------------------------|
|    26: Boolean <RequestEntityTooLarge>k__BackingField (1 byte) |
|----------------------------------------------------------------|
| 27-31: padding (5 bytes)                                       |
|================================================================|
```


Post
```
Type layout for 'SubmissionResponse'
Size: 24 bytes. Paddings: 4 bytes (%16 of empty space)
|=======================================================|
| Object Header (8 bytes)                               |
|-------------------------------------------------------|
| Method Table Ptr (8 bytes)                            |
|=======================================================|
|   0-7: String <Message>k__BackingField (8 bytes)      |
|-------------------------------------------------------|
|  8-15: Exception <Exception>k__BackingField (8 bytes) |
|-------------------------------------------------------|
| 16-19: Int32 <StatusCode>k__BackingField (4 bytes)    |
|-------------------------------------------------------|
| 20-23: padding (4 bytes)                              |
|=======================================================|
```
