### PR TITLE
Reduce DefaultSubmissionClient allocations

### DIFF
--- a/src/Exceptionless/Submission/DefaultSubmissionClient.cs
+++ b/src/Exceptionless/Submission/DefaultSubmissionClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -91,7 +92,7 @@ namespace Exceptionless.Submission {
             if (!config.IsValid)
                 return SettingsResponse.InvalidClientConfig;
 
-            string url = $"{GetConfigServiceEndPoint(config)}/projects/config?v={version}";
+            string url = $"{GetConfigServiceEndPoint(config)}/projects/config?v={version.ToString(CultureInfo.InvariantCulture)}";
 
             HttpResponseMessage response;
             try {
@@ -120,7 +121,7 @@ namespace Exceptionless.Submission {
             if (!config.IsValid)
                 return;
 
-            string url = $"{GetHeartbeatServiceEndPoint(config)}/events/session/heartbeat?id={sessionIdOrUserId}&close={closeSession}";
+            string url = $"{GetHeartbeatServiceEndPoint(config)}/events/session/heartbeat?id={sessionIdOrUserId}&close={closeSession.ToString(CultureInfo.InvariantCulture)}";
             try {
                 _client.Value.AddAuthorizationHeader(config.ApiKey);
                 _client.Value.GetAsync(url).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -165,12 +166,12 @@ namespace Exceptionless.Submission {
         }
 
 #if NET45
-        private bool Validate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors, Func<CertificateData, bool> callback) {
+        private static bool Validate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors, Func<CertificateData, bool> callback) {
             var certData = new CertificateData(sender, certificate, chain, sslPolicyErrors);
             return callback(certData);
         }
 #else
-        private bool Validate(HttpRequestMessage httpRequestMessage, X509Certificate2 certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors, Func<CertificateData, bool> callback) {
+        private static bool Validate(HttpRequestMessage httpRequestMessage, X509Certificate2 certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors, Func<CertificateData, bool> callback) {
             var certData = new CertificateData(httpRequestMessage, certificate, chain, sslPolicyErrors);
             return callback(certData);
         }
@@ -196,7 +197,7 @@ namespace Exceptionless.Submission {
                 } catch { }
             }
 
-            return !String.IsNullOrEmpty(message) ? message : $"{statusCode} {response.ReasonPhrase}";
+            return !String.IsNullOrEmpty(message) ? message : $"{statusCode.ToString(CultureInfo.InvariantCulture)} {response.ReasonPhrase}";
         }
 
         private string GetResponseText(HttpResponseMessage response) {

--- a/src/Exceptionless/Submission/SettingsResponse.cs
+++ b/src/Exceptionless/Submission/SettingsResponse.cs
@@ -3,6 +3,10 @@ using Exceptionless.Models;
 
 namespace Exceptionless.Submission {
     public class SettingsResponse {
+        internal static SettingsResponse NotModified { get; } = new(success: false, message: "Settings have not been modified.");
+        internal static SettingsResponse InvalidConfig { get; } = new(success: false, message: "Invalid configuration settings.");
+        internal static SettingsResponse InvalidClientConfig { get; } = new(success: false, message: "Invalid client configuration settings.");
+
         public SettingsResponse(bool success, SettingsDictionary settings = null, int settingsVersion = -1, Exception exception = null, string message = null) {
             Success = success;
             Settings = settings;

--- a/src/Exceptionless/Submission/SubmissionResponse.cs
+++ b/src/Exceptionless/Submission/SubmissionResponse.cs
@@ -3,7 +3,8 @@ using System.Net;
 
 namespace Exceptionless.Submission {
     public class SubmissionResponse {
-        internal static readonly SubmissionResponse Ok200 = new(200, "OK");
+        internal static SubmissionResponse Ok200 { get; } = new(200, "OK");
+        internal static SubmissionResponse InvalidClientConfig500 { get; } = new(500, "Invalid client configuration settings");
 
         public SubmissionResponse(int statusCode, string message = null, Exception exception = null) {
             StatusCode = statusCode;


### PR DESCRIPTION
* Don't allocate a response for the common paths e.g. `SubmissionResponse == Ok 200`
* Use interpolated strings in preference as that will have a non-boxing; low allocating path in C#10 https://github.com/dotnet/runtime/issues/50635