### PR TITLE
Faster Snake Case Naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ node_modules
 App_Data
 Exceptionless.sln.GhostDoc.xml
 .vs/config/applicationhost.config
+test/Exceptionless.Performance.Tests/BenchmarkDotNet.Artifacts/

--- a/Exceptionless.Net.sln
+++ b/Exceptionless.Net.sln
@@ -82,6 +82,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Exceptionless.SampleLambda"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Exceptionless.SampleLambdaAspNetCore", "samples\Exceptionless.SampleLambdaAspNetCore\Exceptionless.SampleLambdaAspNetCore.csproj", "{D9987952-B891-48B4-AA93-59AA39F33FC4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Exceptionless.Performance.Tests", "test\Exceptionless.Performance.Tests\Exceptionless.Performance.Tests.csproj", "{2541FABD-73EC-44CD-99F1-563EF9E99E3E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -192,6 +194,10 @@ Global
 		{D9987952-B891-48B4-AA93-59AA39F33FC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9987952-B891-48B4-AA93-59AA39F33FC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9987952-B891-48B4-AA93-59AA39F33FC4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2541FABD-73EC-44CD-99F1-563EF9E99E3E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2541FABD-73EC-44CD-99F1-563EF9E99E3E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2541FABD-73EC-44CD-99F1-563EF9E99E3E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2541FABD-73EC-44CD-99F1-563EF9E99E3E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -222,6 +228,7 @@ Global
 		{693ED127-0124-4697-8369-700717615E85} = {2CEE12C6-3840-4C01-A952-D3026B0A662A}
 		{4B26BF7F-85FB-4B41-BF93-661E83A4EDD7} = {2CEE12C6-3840-4C01-A952-D3026B0A662A}
 		{D9987952-B891-48B4-AA93-59AA39F33FC4} = {2CEE12C6-3840-4C01-A952-D3026B0A662A}
+		{2541FABD-73EC-44CD-99F1-563EF9E99E3E} = {847AAE03-9F4A-4920-9E56-8AECB915E2B6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EBB2CC85-FF87-431B-865F-2F110B2A10E6}

--- a/src/Exceptionless/Services/Gen2GcCallback.cs
+++ b/src/Exceptionless/Services/Gen2GcCallback.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+
+namespace System {
+    /// <summary>
+    /// Schedules a callback roughly every gen 2 GC (you may see a Gen 0 an Gen 1 but only once)
+    /// (We can fix this by capturing the Gen 2 count at startup and testing, but I mostly don't care)
+    /// </summary>
+    internal sealed class Gen2GcCallback : CriticalFinalizerObject {
+        private readonly Func<bool>? _callback0;
+        private readonly Func<object, bool>? _callback1;
+        private GCHandle _weakTargetObj;
+
+        private Gen2GcCallback(Func<bool> callback) {
+            _callback0 = callback;
+        }
+
+        private Gen2GcCallback(Func<object, bool> callback, object targetObj) {
+            _callback1 = callback;
+            _weakTargetObj = GCHandle.Alloc(targetObj, GCHandleType.Weak);
+        }
+
+        /// <summary>
+        /// Schedule 'callback' to be called in the next GC.  If the callback returns true it is
+        /// rescheduled for the next Gen 2 GC.  Otherwise the callbacks stop.
+        /// </summary>
+        public static void Register(Func<bool> callback) {
+            // Create a unreachable object that remembers the callback function and target object.
+            new Gen2GcCallback(callback);
+        }
+
+        /// <summary>
+        /// Schedule 'callback' to be called in the next GC.  If the callback returns true it is
+        /// rescheduled for the next Gen 2 GC.  Otherwise the callbacks stop.
+        ///
+        /// NOTE: This callback will be kept alive until either the callback function returns false,
+        /// or the target object dies.
+        /// </summary>
+        public static void Register(Func<object, bool> callback, object targetObj) {
+            // Create a unreachable object that remembers the callback function and target object.
+            new Gen2GcCallback(callback, targetObj);
+        }
+
+        ~Gen2GcCallback() {
+            if (_weakTargetObj.IsAllocated) {
+                // Check to see if the target object is still alive.
+                object? targetObj = _weakTargetObj.Target;
+                if (targetObj == null) {
+                    // The target object is dead, so this callback object is no longer needed.
+                    _weakTargetObj.Free();
+                    return;
+                }
+
+                // Execute the callback method.
+                try {
+                    Debug.Assert(_callback1 != null);
+                    if (!_callback1(targetObj)) {
+                        // If the callback returns false, this callback object is no longer needed.
+                        return;
+                    }
+                }
+                catch {
+                    // Ensure that we still get a chance to resurrect this object, even if the callback throws an exception.
+#if DEBUG
+                    // Except in DEBUG, as we really shouldn't be hitting any exceptions here.
+                    throw;
+#endif
+                }
+            }
+            else {
+                // Execute the callback method.
+                try {
+                    Debug.Assert(_callback0 != null);
+                    if (!_callback0()) {
+                        // If the callback returns false, this callback object is no longer needed.
+                        return;
+                    }
+                }
+                catch {
+                    // Ensure that we still get a chance to resurrect this object, even if the callback throws an exception.
+#if DEBUG
+                    // Except in DEBUG, as we really shouldn't be hitting any exceptions here.
+                    throw;
+#endif
+                }
+            }
+
+            // Resurrect ourselves by re-registering for finalization.
+            GC.ReRegisterForFinalize(this);
+        }
+    }
+}

--- a/test/Exceptionless.Performance.Tests/Exceptionless.Performance.Tests.csproj
+++ b/test/Exceptionless.Performance.Tests/Exceptionless.Performance.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+  </ItemGroup>
+
+</Project>

--- a/test/Exceptionless.Performance.Tests/Program.cs
+++ b/test/Exceptionless.Performance.Tests/Program.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Running;
+
+namespace Exceptionless.Performance.Tests
+{
+    class Program
+    {
+        static void Main(string[] args) {
+            var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly)
+                .Run(args);
+        }
+    }
+}

--- a/test/Exceptionless.Performance.Tests/SnakeCaseNaming.cs
+++ b/test/Exceptionless.Performance.Tests/SnakeCaseNaming.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+using BenchmarkDotNet.Attributes;
+
+namespace Exceptionless.Performance.Tests {
+    [MemoryDiagnoser]
+    public class SnakeCaseNaming {
+        private const int Iterations = 5;
+
+        [ParamsSource(nameof(Words))]
+        public string Word { get; set; }
+
+        public IEnumerable<string> Words => new[]
+        {
+            "z",
+            "A",
+            "AA",
+            "zz",
+            "AzA",
+            "az_A",
+            "azzAzzAzzAzz",
+            "azzzAzzzAzzzAzzzAzzzAzzzAzzz"
+        };
+
+        [GlobalSetup]
+        public void Verify() {
+            var value0 = ToLowerUnderscoredWords(Word);
+            var value1 = ToLowerUnderscoredWordsCreate(Word, new StringBuilder());
+            var value2 = ToLowerUnderscoredWordsCached(Word);
+
+            if (value0 != value1) throw new InvalidOperationException($"{value0} != {value1}");
+            if (value1 != value2) throw new InvalidOperationException($"{value1} != {value2}");
+        }
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = Iterations)]
+        public string SnakeCase() {
+            string value = "";
+            for (int i = 0; i < Iterations; i++) {
+                value = Operation(value);
+            }
+
+            return value;
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            string Operation(string previous) {
+                return ToLowerUnderscoredWords(Word);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public string StringBuilderCached() {
+            string value = "";
+            for (int i = 0; i < Iterations; i++) {
+                value = Operation(value);
+            }
+
+            return value;
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            string Operation(string previous) {
+                var name = Word;
+                ref var builder = ref s_builder;
+                var sb = builder ?? new StringBuilder(name.Length + 5);
+                builder = null;
+                name = ToLowerUnderscoredWordsCreate(name, sb);
+
+                if (value.Length <= 100) {
+                    sb.Clear();
+                    builder = sb;
+                }
+
+                return name;
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public string ConversionCached() {
+            string value = "";
+            for (int i = 0; i < Iterations; i++) {
+                value = Operation(value);
+            }
+
+            return value;
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            string Operation(string previous) {
+                return ToLowerUnderscoredWordsCached(Word);
+            }
+        }
+
+        public static string ToLowerUnderscoredWords(string value) {
+            var builder = new StringBuilder(value.Length + 10);
+            for (int index = 0; index < value.Length; index++) {
+                char c = value[index];
+                if (Char.IsUpper(c)) {
+                    if (index > 0 && value[index - 1] != '_')
+                        builder.Append('_');
+
+                    builder.Append(Char.ToLower(c));
+                }
+                else {
+                    builder.Append(c);
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        private static readonly ConcurrentDictionary<string, string> s_lookUp = new();
+        [ThreadStatic] private static StringBuilder? s_builder;
+
+        public static string ToLowerUnderscoredWordsCached(string name) {
+            if (string.IsNullOrEmpty(name)) return name;
+
+            var lookUp = s_lookUp;
+            if (lookUp.TryGetValue(name, out string value)) return value;
+
+            ref var builder = ref s_builder;
+            var sb = builder ?? new StringBuilder(name.Length + 5);
+            builder = null;
+
+            value = ToLowerUnderscoredWordsCreate(name, sb);
+            lookUp[name] = value;
+
+            if (value.Length <= 100) {
+                sb.Clear();
+                builder = sb;
+            }
+
+            return value;
+        }
+
+        public static string ToLowerUnderscoredWordsCreate(string value, StringBuilder builder) {
+            for (int index = 0; index < value.Length; index++) {
+                char c = value[index];
+                if (Char.IsUpper(c)) {
+                    if (index > 0 && value[index - 1] != '_')
+                        builder.Append('_');
+
+                    builder.Append(Char.ToLower(c));
+                }
+                else {
+                    builder.Append(c);
+                }
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/test/Exceptionless.Performance.Tests/SnakeCaseNaming.cs
+++ b/test/Exceptionless.Performance.Tests/SnakeCaseNaming.cs
@@ -16,14 +16,11 @@ namespace Exceptionless.Performance.Tests {
 
         public IEnumerable<string> Words => new[]
         {
-            "z",
             "A",
-            "AA",
-            "zz",
-            "AzA",
-            "az_A",
-            "azzAzzAzzAzz",
-            "azzzAzzzAzzzAzzzAzzzAzzzAzzz"
+            "property",
+            "Message",
+            "StackTrace",
+            "InnerException",
         };
 
         [GlobalSetup]


### PR DESCRIPTION
Up to x3.5 faster snake casing for Json properties via caching; also dumps the cache at Gen2.

Move to `ConversionCached` approach; less allocations and much faster conversion (also incorporates the `StringBuilderCached` for new strings)

|              Method |           Word |      Mean | Ratio |  Gen 0 | Allocated |
|-------------------- |--------------- |----------:|------:|-------:|----------:|
|           SnakeCase |              A |  37.22 ns |  1.00 | 0.0255 |     120 B |
| StringBuilderCached |              A |  35.24 ns |  0.94 | 0.0051 |      24 B |
|    ConversionCached |              A |  18.99 ns |  0.51 |      - |         - |
|                     |                |           |       |        |           |
|           SnakeCase | InnerException | 109.54 ns |  1.00 | 0.0374 |     176 B |
| StringBuilderCached | InnerException | 101.12 ns |  0.92 | 0.0118 |      56 B |
|    ConversionCached | InnerException |  23.95 ns |  0.22 |      - |         - |
|                     |                |           |       |        |           |
|           SnakeCase |        Message |  65.09 ns |  1.00 | 0.0322 |     152 B |
| StringBuilderCached |        Message |  59.97 ns |  0.92 | 0.0085 |      40 B |
|    ConversionCached |        Message |  22.86 ns |  0.35 |      - |         - |
|                     |                |           |       |        |           |
|           SnakeCase |     StackTrace |  91.76 ns |  1.00 | 0.0340 |     160 B |
| StringBuilderCached |     StackTrace |  82.57 ns |  0.90 | 0.0101 |      48 B |
|    ConversionCached |     StackTrace |  22.07 ns |  0.24 |      - |         - |
|                     |                |           |       |        |           |
|           SnakeCase |       property |  55.52 ns |  1.00 | 0.0322 |     152 B |
| StringBuilderCached |       property |  55.52 ns |  1.00 | 0.0085 |      40 B |
|    ConversionCached |       property |  21.86 ns |  0.39 |      - |         - |