### PR TITLE
Skip pattern maching for empty sets

### DIFF
--- a/src/Exceptionless/Extensions/DataDictionaryExtensions.cs
+++ b/src/Exceptionless/Extensions/DataDictionaryExtensions.cs
@@ -111,7 +111,7 @@ namespace Exceptionless {
                 int index = 1;
                 while (data.Data.ContainsKey(name))
                     name = dataType.Name + index++;
-            } else if (name.AnyWildcardMatches(exclusions, true)) {
+            } else if (exclusions.Length > 0 && name.AnyWildcardMatches(exclusions, true)) {
                 return;
             }
 

--- a/src/Exceptionless/Serializer/DefaultJsonSerializer.cs
+++ b/src/Exceptionless/Serializer/DefaultJsonSerializer.cs
@@ -47,11 +47,10 @@ namespace Exceptionless.Serializer {
             if (maxDepth < 1)
                 maxDepth = Int32.MaxValue;
 
-            var excludedPropertyNames = new HashSet<string>(exclusions ?? new string[0], StringComparer.OrdinalIgnoreCase);            
             using (var sw = new StringWriter()) {
-                using (var jw = new JsonTextWriterWithExclusions(sw, excludedPropertyNames)) {
+                using (var jw = new JsonTextWriterWithExclusions(sw, exclusions)) {
                     jw.Formatting = Formatting.None;
-                    Func<JsonProperty, object, bool> include = (property, value) => ShouldSerialize(jw, property, value, maxDepth, excludedPropertyNames);
+                    Func<JsonProperty, object, bool> include = (property, value) => ShouldSerialize(jw, property, value, maxDepth, exclusions);
                     var resolver = new ExceptionlessContractResolver(include);
                     serializer.ContractResolver = resolver;
                     if (continueOnSerializationError)
@@ -71,9 +70,9 @@ namespace Exceptionless.Serializer {
             return JsonConvert.DeserializeObject(json, type, _serializerSettings);
         }
 
-        private bool ShouldSerialize(JsonTextWriterWithDepth jw, JsonProperty property, object obj, int maxDepth, ISet<string> excludedPropertyNames) {
+        private bool ShouldSerialize(JsonTextWriterWithDepth jw, JsonProperty property, object obj, int maxDepth, string[] excludedPropertyNames) {
             try {
-                if (excludedPropertyNames != null && (property.UnderlyingName.AnyWildcardMatches(excludedPropertyNames, true) || property.PropertyName.AnyWildcardMatches(excludedPropertyNames, true)))
+                if (excludedPropertyNames != null && (property.UnderlyingName.AnyWildcardMatches(excludedPropertyNames, ignoreCase: true) || property.PropertyName.AnyWildcardMatches(excludedPropertyNames, ignoreCase: true)))
                     return false;
 
                 bool isPrimitiveType = DefaultContractResolver.IsJsonPrimitiveType(property.PropertyType);

--- a/src/Exceptionless/Serializer/DefaultJsonSerializer.cs
+++ b/src/Exceptionless/Serializer/DefaultJsonSerializer.cs
@@ -72,7 +72,7 @@ namespace Exceptionless.Serializer {
 
         private bool ShouldSerialize(JsonTextWriterWithDepth jw, JsonProperty property, object obj, int maxDepth, string[] excludedPropertyNames) {
             try {
-                if (excludedPropertyNames != null && (property.UnderlyingName.AnyWildcardMatches(excludedPropertyNames, ignoreCase: true) || property.PropertyName.AnyWildcardMatches(excludedPropertyNames, ignoreCase: true)))
+                if (excludedPropertyNames != null && excludedPropertyNames.Length > 0 && (property.UnderlyingName.AnyWildcardMatches(excludedPropertyNames, ignoreCase: true) || property.PropertyName.AnyWildcardMatches(excludedPropertyNames, ignoreCase: true)))
                     return false;
 
                 bool isPrimitiveType = DefaultContractResolver.IsJsonPrimitiveType(property.PropertyType);

--- a/src/Exceptionless/Serializer/JsonTextWriterWithExclusions.cs
+++ b/src/Exceptionless/Serializer/JsonTextWriterWithExclusions.cs
@@ -14,8 +14,8 @@ namespace Exceptionless.Serializer
         
         public override bool ShouldWriteProperty(string name) {
             var exclusions = _excludedPropertyNames;
-            return exclusions is not null &&
-                exclusions.Length > 0 && 
+            return exclusions is null ||
+                exclusions.Length == 0 || 
                 !name.AnyWildcardMatches(exclusions, ignoreCase: true);
         }
     }

--- a/src/Exceptionless/Serializer/JsonTextWriterWithExclusions.cs
+++ b/src/Exceptionless/Serializer/JsonTextWriterWithExclusions.cs
@@ -5,15 +5,18 @@ using Exceptionless.Extensions;
 
 namespace Exceptionless.Serializer
 {
-    internal class JsonTextWriterWithExclusions : JsonTextWriterWithDepth {
-        private readonly ISet<string> _excludedPropertyNames;
+    internal sealed class JsonTextWriterWithExclusions : JsonTextWriterWithDepth {
+        private readonly string[] _excludedPropertyNames;
         
-        public JsonTextWriterWithExclusions(TextWriter textWriter, ISet<string> excludedPropertyNames) : base(textWriter) {
+        public JsonTextWriterWithExclusions(TextWriter textWriter, string[] excludedPropertyNames) : base(textWriter) {
             _excludedPropertyNames = excludedPropertyNames;
         }
         
         public override bool ShouldWriteProperty(string name) {
-            return !name.AnyWildcardMatches(_excludedPropertyNames, true);
+            var exclusions = _excludedPropertyNames;
+            return exclusions is not null &&
+                exclusions.Length > 0 && 
+                !name.AnyWildcardMatches(exclusions, ignoreCase: true);
         }
     }
 }


### PR DESCRIPTION
Gets called a lot with empty sets so can skip that and the `HashSet` creation and use `string[]` directly