### PR TITLE
Add additional code analysis rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -76,3 +76,1103 @@ csharp_new_line_before_catch = false:error
 csharp_new_line_before_finally = false:error
 csharp_new_line_before_members_in_object_initializers = false:error
 csharp_new_line_before_members_in_anonymous_types = false:error
+
+# Microsoft.Analyzers.ManagedCodeAnalysis
+# Description: Microsoft.Analyzers.ManagedCodeAnalysis
+
+# Analyzer threw an exception
+dotnet_diagnostic.AD0001.severity = warning
+
+# Ensure minimum API surface is respected
+dotnet_diagnostic.BCL0001.severity = warning
+
+# AppContext default value expected to be true
+dotnet_diagnostic.BCL0010.severity = warning
+
+# AppContext default value defined in if statement with incorrect pattern
+dotnet_diagnostic.BCL0011.severity = warning
+
+# AppContext default value defined in if statement at root of switch case
+dotnet_diagnostic.BCL0012.severity = warning
+
+# Invalid P/Invoke call
+dotnet_diagnostic.BCL0015.severity = none
+
+# Invalid SR.Format call
+dotnet_diagnostic.BCL0020.severity = warning
+
+# Do not declare static members on generic types
+dotnet_diagnostic.CA1000.severity = none
+
+# Types that own disposable fields should be disposable
+dotnet_diagnostic.CA1001.severity = none
+
+# Do not expose generic lists
+dotnet_diagnostic.CA1002.severity = none
+
+# Use generic event handler instances
+dotnet_diagnostic.CA1003.severity = none
+
+# Avoid excessive parameters on generic types
+dotnet_diagnostic.CA1005.severity = none
+
+# Enums should have zero value
+dotnet_diagnostic.CA1008.severity = none
+
+# Generic interface should also be implemented
+dotnet_diagnostic.CA1010.severity = none
+
+# Abstract types should not have constructors
+dotnet_diagnostic.CA1012.severity = none
+
+# Mark assemblies with CLSCompliant
+dotnet_diagnostic.CA1014.severity = none
+
+# Mark assemblies with assembly version
+dotnet_diagnostic.CA1016.severity = none
+
+# Mark assemblies with ComVisible
+dotnet_diagnostic.CA1017.severity = none
+
+# Mark attributes with AttributeUsageAttribute
+dotnet_diagnostic.CA1018.severity = warning
+
+# Define accessors for attribute arguments
+dotnet_diagnostic.CA1019.severity = none
+
+# Use properties where appropriate
+dotnet_diagnostic.CA1024.severity = none
+
+# Mark enums with FlagsAttribute
+dotnet_diagnostic.CA1027.severity = none
+
+# Enum Storage should be Int32
+dotnet_diagnostic.CA1028.severity = none
+
+# Use events where appropriate
+dotnet_diagnostic.CA1030.severity = none
+
+# Do not catch general exception types
+dotnet_diagnostic.CA1031.severity = none
+
+dotnet_diagnostic.CA1032.severity = none
+
+# Interface methods should be callable by child types
+dotnet_diagnostic.CA1033.severity = none
+
+dotnet_diagnostic.CA1034.severity = none
+
+# Override methods on comparable types
+dotnet_diagnostic.CA1036.severity = none
+
+# Avoid empty interfaces
+dotnet_diagnostic.CA1040.severity = none
+
+# Provide ObsoleteAttribute message
+dotnet_diagnostic.CA1041.severity = none
+
+# Use Integral Or String Argument For Indexers
+dotnet_diagnostic.CA1043.severity = none
+
+# Properties should not be write only
+dotnet_diagnostic.CA1044.severity = none
+
+# Do not overload equality operator on reference types
+dotnet_diagnostic.CA1046.severity = none
+
+# Do not declare protected member in sealed type
+dotnet_diagnostic.CA1047.severity = warning
+
+# Declare types in namespaces
+dotnet_diagnostic.CA1050.severity = warning
+
+# Do not declare visible instance fields
+dotnet_diagnostic.CA1051.severity = none
+
+# Static holder types should be Static or NotInheritable
+dotnet_diagnostic.CA1052.severity = none
+
+# Uri parameters should not be strings
+dotnet_diagnostic.CA1054.severity = none
+
+# Uri return values should not be strings
+dotnet_diagnostic.CA1055.severity = none
+
+# Uri properties should not be strings
+dotnet_diagnostic.CA1056.severity = none
+
+# Types should not extend certain base types
+dotnet_diagnostic.CA1058.severity = none
+
+# Do not hide base class methods
+dotnet_diagnostic.CA1061.severity = none
+
+# Validate arguments of public methods
+dotnet_diagnostic.CA1062.severity = none
+
+# Implement IDisposable Correctly
+dotnet_diagnostic.CA1063.severity = none
+
+# Exceptions should be public
+dotnet_diagnostic.CA1064.severity = none
+
+# Do not raise exceptions in unexpected locations
+dotnet_diagnostic.CA1065.severity = none
+
+# Implement IEquatable when overriding Object.Equals
+dotnet_diagnostic.CA1066.severity = none
+
+# Override Object.Equals(object) when implementing IEquatable<T>
+dotnet_diagnostic.CA1067.severity = none
+
+# CancellationToken parameters must come last
+dotnet_diagnostic.CA1068.severity = none
+
+# Enums values should not be duplicated
+dotnet_diagnostic.CA1069.severity = none
+
+# Do not declare event fields as virtual
+dotnet_diagnostic.CA1070.severity = warning
+
+# Avoid using cref tags with a prefix
+dotnet_diagnostic.CA1200.severity = warning
+
+# Do not pass literals as localized parameters
+dotnet_diagnostic.CA1303.severity = none
+
+# Specify CultureInfo
+dotnet_diagnostic.CA1304.severity = none
+
+# Specify IFormatProvider
+dotnet_diagnostic.CA1305.severity = none
+
+# Specify StringComparison
+dotnet_diagnostic.CA1307.severity = none
+
+# Normalize strings to uppercase
+dotnet_diagnostic.CA1308.severity = none
+
+# Use ordinal stringcomparison
+dotnet_diagnostic.CA1309.severity = none
+
+# P/Invokes should not be visible
+dotnet_diagnostic.CA1401.severity = warning
+
+# Do not use 'OutAttribute' on string parameters for P/Invokes
+dotnet_diagnostic.CA1417.severity = warning
+
+# Avoid excessive complexity
+dotnet_diagnostic.CA1502.severity = none
+
+# Avoid unmaintainable code
+dotnet_diagnostic.CA1505.severity = none
+
+# Avoid excessive class coupling
+dotnet_diagnostic.CA1506.severity = none
+
+# Use nameof to express symbol names
+dotnet_diagnostic.CA1507.severity = suggestion
+
+# Avoid dead conditional code
+dotnet_diagnostic.CA1508.severity = none
+
+# Invalid entry in code metrics rule specification file
+dotnet_diagnostic.CA1509.severity = none
+
+# Do not name enum values 'Reserved'
+dotnet_diagnostic.CA1700.severity = none
+
+dotnet_diagnostic.CA1707.severity = none
+
+# Identifiers should have correct suffix
+dotnet_diagnostic.CA1710.severity = none
+
+# Identifiers should not have incorrect suffix
+dotnet_diagnostic.CA1711.severity = none
+
+# Do not prefix enum values with type name
+dotnet_diagnostic.CA1712.severity = none
+
+dotnet_diagnostic.CA1714.severity = none
+
+# Identifiers should have correct prefix
+dotnet_diagnostic.CA1715.severity = none
+
+# Identifiers should not match keywords
+dotnet_diagnostic.CA1716.severity = none
+
+dotnet_diagnostic.CA1717.severity = none
+
+# Identifier contains type name
+dotnet_diagnostic.CA1720.severity = none
+
+# Property names should not match get methods
+dotnet_diagnostic.CA1721.severity = none
+
+# Type names should not match namespaces
+dotnet_diagnostic.CA1724.severity = none
+
+# Review unused parameters
+dotnet_diagnostic.CA1801.severity = none
+
+# Use literals where appropriate
+dotnet_diagnostic.CA1802.severity = warning
+
+# Do not initialize unnecessarily
+dotnet_diagnostic.CA1805.severity = none
+
+dotnet_diagnostic.CA1806.severity = none
+
+# Initialize reference type static fields inline
+dotnet_diagnostic.CA1810.severity = warning
+
+# Avoid uninstantiated internal classes
+dotnet_diagnostic.CA1812.severity = none
+
+dotnet_diagnostic.CA1814.severity = none
+
+dotnet_diagnostic.CA1815.severity = none
+
+# Dispose methods should call SuppressFinalize
+dotnet_diagnostic.CA1816.severity = none
+
+dotnet_diagnostic.CA1819.severity = none
+
+# Test for empty strings using string length
+dotnet_diagnostic.CA1820.severity = none
+
+# Remove empty Finalizers
+dotnet_diagnostic.CA1821.severity = warning
+
+# Mark members as static
+dotnet_diagnostic.CA1822.severity = none
+
+# Avoid unused private fields
+dotnet_diagnostic.CA1823.severity = warning
+
+# Mark assemblies with NeutralResourcesLanguageAttribute
+dotnet_diagnostic.CA1824.severity = suggestion
+
+# Avoid zero-length array allocations.
+dotnet_diagnostic.CA1825.severity = warning
+
+# Do not use Count() or LongCount() when Any() can be used
+dotnet_diagnostic.CA1827.severity = warning
+
+# Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+dotnet_diagnostic.CA1828.severity = warning
+
+# Use Length/Count property instead of Count() when available
+dotnet_diagnostic.CA1829.severity = warning
+
+# Prefer strongly-typed Append and Insert method overloads on StringBuilder.
+dotnet_diagnostic.CA1830.severity = warning
+
+# Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1831.severity = warning
+
+# Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1832.severity = warning
+
+# Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1833.severity = warning
+
+# Consider using 'StringBuilder.Append(char)' when applicable.
+dotnet_diagnostic.CA1834.severity = warning
+
+# Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+dotnet_diagnostic.CA1835.severity = warning
+
+# Prefer IsEmpty over Count
+dotnet_diagnostic.CA1836.severity = warning
+
+# Use 'Environment.ProcessId'
+dotnet_diagnostic.CA1837.severity = suggestion
+
+# Avoid 'StringBuilder' parameters for P/Invokes
+dotnet_diagnostic.CA1838.severity = warning
+
+# Dispose objects before losing scope
+dotnet_diagnostic.CA2000.severity = none
+
+# Do not lock on objects with weak identity
+dotnet_diagnostic.CA2002.severity = none
+
+# Consider calling ConfigureAwait on the awaited task
+dotnet_diagnostic.CA2007.severity = suggestion
+
+# Do not create tasks without passing a TaskScheduler
+dotnet_diagnostic.CA2008.severity = suggestion
+
+# Do not call ToImmutableCollection on an ImmutableCollection value
+dotnet_diagnostic.CA2009.severity = warning
+
+# Avoid infinite recursion
+dotnet_diagnostic.CA2011.severity = warning
+
+# Use ValueTasks correctly
+dotnet_diagnostic.CA2012.severity = warning
+
+# Do not use ReferenceEquals with value types
+dotnet_diagnostic.CA2013.severity = warning
+
+# Do not use stackalloc in loops.
+dotnet_diagnostic.CA2014.severity = warning
+
+# Do not define finalizers for types derived from MemoryManager<T>
+dotnet_diagnostic.CA2015.severity = warning
+
+# Forward the 'CancellationToken' parameter to methods that take one
+dotnet_diagnostic.CA2016.severity = warning
+
+# Review SQL queries for security vulnerabilities
+dotnet_diagnostic.CA2100.severity = none
+
+# Specify marshaling for P/Invoke string arguments
+dotnet_diagnostic.CA2101.severity = none
+
+# Review visible event handlers
+dotnet_diagnostic.CA2109.severity = none
+
+# Seal methods that satisfy private interfaces
+dotnet_diagnostic.CA2119.severity = none
+
+# Do Not Catch Corrupted State Exceptions
+dotnet_diagnostic.CA2153.severity = none
+
+# Do not raise reserved exception types
+dotnet_diagnostic.CA2201.severity = none
+
+# Instantiate argument exceptions correctly
+dotnet_diagnostic.CA2208.severity = suggestion
+
+# Non-constant fields should not be visible
+dotnet_diagnostic.CA2211.severity = none
+
+# Disposable fields should be disposed
+dotnet_diagnostic.CA2213.severity = none
+
+# Dispose methods should call base class dispose
+dotnet_diagnostic.CA2215.severity = none
+
+# Disposable types should declare finalizer
+dotnet_diagnostic.CA2216.severity = none
+
+dotnet_diagnostic.CA2219.severity = none
+
+# Override Equals on overloading operator equals
+dotnet_diagnostic.CA2224.severity = none
+
+# Operator overloads have named alternates
+dotnet_diagnostic.CA2225.severity = none
+
+# Operators should have symmetrical overloads
+dotnet_diagnostic.CA2226.severity = none
+
+# Collection properties should be read only
+dotnet_diagnostic.CA2227.severity = none
+
+# Overload operator equals on overriding value type Equals
+dotnet_diagnostic.CA2231.severity = none
+
+# Pass system uri objects instead of strings
+dotnet_diagnostic.CA2234.severity = none
+
+# Mark all non-serializable fields
+dotnet_diagnostic.CA2235.severity = none
+
+# Provide correct arguments to formatting methods
+dotnet_diagnostic.CA2241.severity = warning
+
+# Test for NaN correctly
+dotnet_diagnostic.CA2242.severity = warning
+
+# Attribute string literals should parse correctly
+dotnet_diagnostic.CA2243.severity = none
+
+# Do not duplicate indexed element initializations
+dotnet_diagnostic.CA2244.severity = none
+
+# Do not assign a property to itself.
+dotnet_diagnostic.CA2245.severity = warning
+
+# Assigning symbol and its member in the same statement.
+dotnet_diagnostic.CA2246.severity = none
+
+# Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum.
+dotnet_diagnostic.CA2247.severity = warning
+
+# Provide correct 'enum' argument to 'Enum.HasFlag'
+dotnet_diagnostic.CA2248.severity = warning
+
+# Consider using 'string.Contains' instead of 'string.IndexOf'
+dotnet_diagnostic.CA2249.severity = suggestion
+
+# Do not use insecure deserializer BinaryFormatter
+dotnet_diagnostic.CA2300.severity = none
+
+# Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+dotnet_diagnostic.CA2301.severity = none
+
+# Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+dotnet_diagnostic.CA2302.severity = none
+
+# Do not use insecure deserializer LosFormatter
+dotnet_diagnostic.CA2305.severity = none
+
+# Do not use insecure deserializer NetDataContractSerializer
+dotnet_diagnostic.CA2310.severity = none
+
+# Do not deserialize without first setting NetDataContractSerializer.Binder
+dotnet_diagnostic.CA2311.severity = none
+
+# Ensure NetDataContractSerializer.Binder is set before deserializing
+dotnet_diagnostic.CA2312.severity = none
+
+# Do not use insecure deserializer ObjectStateFormatter
+dotnet_diagnostic.CA2315.severity = none
+
+# Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+dotnet_diagnostic.CA2321.severity = none
+
+# Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+dotnet_diagnostic.CA2322.severity = none
+
+# Do not use TypeNameHandling values other than None
+dotnet_diagnostic.CA2326.severity = none
+
+# Do not use DataTable.ReadXml() with untrusted data
+dotnet_diagnostic.CA2350.severity = none
+
+# Do not use DataSet.ReadXml() with untrusted data
+dotnet_diagnostic.CA2351.severity = none
+
+# Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+dotnet_diagnostic.CA2352.severity = none
+
+# Unsafe DataSet or DataTable in serializable type
+dotnet_diagnostic.CA2353.severity = none
+
+# Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+dotnet_diagnostic.CA2354.severity = none
+
+# Unsafe DataSet or DataTable type found in deserializable object graph
+dotnet_diagnostic.CA2355.severity = none
+
+# Unsafe DataSet or DataTable type in web deserializable object graph
+dotnet_diagnostic.CA2356.severity = none
+
+# Ensure autogenerated class containing DataSet.ReadXml() is not used with untrusted data
+dotnet_diagnostic.CA2361.severity = none
+
+# Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+dotnet_diagnostic.CA2362.severity = none
+
+# Review code for SQL injection vulnerabilities
+dotnet_diagnostic.CA3001.severity = none
+
+# Review code for XSS vulnerabilities
+dotnet_diagnostic.CA3002.severity = none
+
+# Review code for file path injection vulnerabilities
+dotnet_diagnostic.CA3003.severity = none
+
+# Review code for information disclosure vulnerabilities
+dotnet_diagnostic.CA3004.severity = none
+
+# Review code for LDAP injection vulnerabilities
+dotnet_diagnostic.CA3005.severity = none
+
+# Review code for process command injection vulnerabilities
+dotnet_diagnostic.CA3006.severity = none
+
+# Review code for open redirect vulnerabilities
+dotnet_diagnostic.CA3007.severity = none
+
+# Review code for XPath injection vulnerabilities
+dotnet_diagnostic.CA3008.severity = none
+
+# Review code for XML injection vulnerabilities
+dotnet_diagnostic.CA3009.severity = none
+
+# Review code for XAML injection vulnerabilities
+dotnet_diagnostic.CA3010.severity = none
+
+# Review code for DLL injection vulnerabilities
+dotnet_diagnostic.CA3011.severity = none
+
+# Review code for regex injection vulnerabilities
+dotnet_diagnostic.CA3012.severity = none
+
+# Do Not Add Schema By URL
+dotnet_diagnostic.CA3061.severity = warning
+
+# Insecure DTD processing in XML
+dotnet_diagnostic.CA3075.severity = suggestion
+
+# Insecure XSLT script processing.
+dotnet_diagnostic.CA3076.severity = suggestion
+
+# Insecure Processing in API Design, XmlDocument and XmlTextReader
+dotnet_diagnostic.CA3077.severity = suggestion
+
+# Mark Verb Handlers With Validate Antiforgery Token
+dotnet_diagnostic.CA3147.severity = warning
+
+# Do Not Use Weak Cryptographic Algorithms
+dotnet_diagnostic.CA5350.severity = warning
+
+# Do Not Use Broken Cryptographic Algorithms
+dotnet_diagnostic.CA5351.severity = warning
+
+# Review cipher mode usage with cryptography experts
+dotnet_diagnostic.CA5358.severity = none
+
+# Do Not Disable Certificate Validation
+dotnet_diagnostic.CA5359.severity = warning
+
+# Do Not Call Dangerous Methods In Deserialization
+dotnet_diagnostic.CA5360.severity = warning
+
+# Do Not Disable SChannel Use of Strong Crypto
+dotnet_diagnostic.CA5361.severity = warning
+
+# Potential reference cycle in deserialized object graph
+dotnet_diagnostic.CA5362.severity = none
+
+# Do Not Disable Request Validation
+dotnet_diagnostic.CA5363.severity = warning
+
+# Do Not Use Deprecated Security Protocols
+dotnet_diagnostic.CA5364.severity = warning
+
+# Do Not Disable HTTP Header Checking
+dotnet_diagnostic.CA5365.severity = warning
+
+# Use XmlReader For DataSet Read Xml
+dotnet_diagnostic.CA5366.severity = none
+
+# Do Not Serialize Types With Pointer Fields
+dotnet_diagnostic.CA5367.severity = none
+
+# Set ViewStateUserKey For Classes Derived From Page
+dotnet_diagnostic.CA5368.severity = warning
+
+# Use XmlReader For Deserialize
+dotnet_diagnostic.CA5369.severity = none
+
+# Use XmlReader For Validating Reader
+dotnet_diagnostic.CA5370.severity = warning
+
+# Use XmlReader For Schema Read
+dotnet_diagnostic.CA5371.severity = none
+
+# Use XmlReader For XPathDocument
+dotnet_diagnostic.CA5372.severity = none
+
+# Do not use obsolete key derivation function
+dotnet_diagnostic.CA5373.severity = warning
+
+# Do Not Use XslTransform
+dotnet_diagnostic.CA5374.severity = warning
+
+# Do Not Use Account Shared Access Signature
+dotnet_diagnostic.CA5375.severity = none
+
+# Use SharedAccessProtocol HttpsOnly
+dotnet_diagnostic.CA5376.severity = warning
+
+# Use Container Level Access Policy
+dotnet_diagnostic.CA5377.severity = warning
+
+# Do not disable ServicePointManagerSecurityProtocols
+dotnet_diagnostic.CA5378.severity = warning
+
+# Do Not Use Weak Key Derivation Function Algorithm
+dotnet_diagnostic.CA5379.severity = warning
+
+# Do Not Add Certificates To Root Store
+dotnet_diagnostic.CA5380.severity = warning
+
+# Ensure Certificates Are Not Added To Root Store
+dotnet_diagnostic.CA5381.severity = warning
+
+# Use Secure Cookies In ASP.Net Core
+dotnet_diagnostic.CA5382.severity = none
+
+# Ensure Use Secure Cookies In ASP.Net Core
+dotnet_diagnostic.CA5383.severity = none
+
+# Do Not Use Digital Signature Algorithm (DSA)
+dotnet_diagnostic.CA5384.severity = suggestion
+
+# Use Rivest–Shamir–Adleman (RSA) Algorithm With Sufficient Key Size
+dotnet_diagnostic.CA5385.severity = warning
+
+# Avoid hardcoding SecurityProtocolType value
+dotnet_diagnostic.CA5386.severity = none
+
+# Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+dotnet_diagnostic.CA5387.severity = none
+
+# Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+dotnet_diagnostic.CA5388.severity = none
+
+# Do Not Add Archive Item's Path To The Target File System Path
+dotnet_diagnostic.CA5389.severity = none
+
+# Do not hard-code encryption key
+dotnet_diagnostic.CA5390.severity = none
+
+# Use antiforgery tokens in ASP.NET Core MVC controllers
+dotnet_diagnostic.CA5391.severity = none
+
+# Use DefaultDllImportSearchPaths attribute for P/Invokes
+dotnet_diagnostic.CA5392.severity = none
+
+# Do not use unsafe DllImportSearchPath value
+dotnet_diagnostic.CA5393.severity = none
+
+# Do not use insecure randomness
+dotnet_diagnostic.CA5394.severity = none
+
+# Miss HttpVerb attribute for action methods
+dotnet_diagnostic.CA5395.severity = none
+
+# Set HttpOnly to true for HttpCookie
+dotnet_diagnostic.CA5396.severity = none
+
+# Do not use deprecated SslProtocols values
+dotnet_diagnostic.CA5397.severity = none
+
+# Avoid hardcoded SslProtocols values
+dotnet_diagnostic.CA5398.severity = none
+
+# HttpClients should enable certificate revocation list checks
+dotnet_diagnostic.CA5399.severity = none
+
+# Ensure HttpClient certificate revocation list check is not disabled
+dotnet_diagnostic.CA5400.severity = none
+
+# Do not use CreateEncryptor with non-default IV
+dotnet_diagnostic.CA5401.severity = none
+
+# Use CreateEncryptor with the default IV
+dotnet_diagnostic.CA5402.severity = none
+
+# Do not hard-code certificate
+dotnet_diagnostic.CA5403.severity = none
+
+# Avoid using accessing Assembly file path when publishing as a single-file
+dotnet_diagnostic.IL3000.severity = none
+
+# Avoid using accessing Assembly file path when publishing as a single-file
+dotnet_diagnostic.IL3001.severity = none
+
+# XML comments
+dotnet_diagnostic.SA0001.severity = suggestion
+
+dotnet_diagnostic.SA1000.severity = none
+
+dotnet_diagnostic.SA1001.severity = none
+
+# Semicolons should not be preceded by a space
+dotnet_diagnostic.SA1002.severity = warning
+
+dotnet_diagnostic.SA1003.severity = none
+
+# Documentation line should begin with a space
+dotnet_diagnostic.SA1004.severity = warning
+
+# Single line comment should begin with a space
+dotnet_diagnostic.SA1005.severity = suggestion
+
+# Region should not be preceded by a space
+dotnet_diagnostic.SA1006.severity = warning
+
+# Opening parenthesis should not be preceded by a space
+dotnet_diagnostic.SA1008.severity = suggestion
+
+# Closing parenthesis should not be followed by a space
+dotnet_diagnostic.SA1009.severity = suggestion
+
+# Opening square brackets should not be preceded by a space
+dotnet_diagnostic.SA1010.severity = warning
+
+# Closing square bracket should be followed by a space
+dotnet_diagnostic.SA1011.severity = suggestion
+
+# Opening brace should be followed by a space
+dotnet_diagnostic.SA1012.severity = suggestion
+
+# Closing brace should be preceded by a space
+dotnet_diagnostic.SA1013.severity = suggestion
+
+# Opening generic brackets should not be preceded by a space
+dotnet_diagnostic.SA1014.severity = warning
+
+# Closing generic bracket should not be followed by a space
+dotnet_diagnostic.SA1015.severity = suggestion
+
+dotnet_diagnostic.SA1019.severity = none
+
+# Increment symbol '++' should not be preceded by a space
+dotnet_diagnostic.SA1020.severity = warning
+
+# Negative sign should be preceded by a space
+dotnet_diagnostic.SA1021.severity = suggestion
+
+# Dereference symbol '*' should not be preceded by a space.
+dotnet_diagnostic.SA1023.severity = warning
+
+# Colon should be followed by a space
+dotnet_diagnostic.SA1024.severity = warning
+
+# Code should not contain multiple whitespace characters in a row
+dotnet_diagnostic.SA1025.severity = suggestion
+
+dotnet_diagnostic.SA1026.severity = none
+
+dotnet_diagnostic.SA1027.severity = none
+
+dotnet_diagnostic.SA1028.severity = none
+
+# Do not prefix calls with base unless local implementation exists
+dotnet_diagnostic.SA1100.severity = suggestion
+
+dotnet_diagnostic.SA1101.severity = none
+
+dotnet_diagnostic.SA1102.severity = warning
+
+# Code should not contain empty statements
+dotnet_diagnostic.SA1106.severity = suggestion
+
+# Code should not contain multiple statements on one line
+dotnet_diagnostic.SA1107.severity = suggestion
+
+dotnet_diagnostic.SA1108.severity = none
+
+# Opening parenthesis or bracket should be on declaration line
+dotnet_diagnostic.SA1110.severity = suggestion
+
+# Closing parenthesis should be on line of last parameter
+dotnet_diagnostic.SA1111.severity = suggestion
+
+dotnet_diagnostic.SA1112.severity = none
+
+dotnet_diagnostic.SA1113.severity = none
+
+# Parameter list should follow declaration
+dotnet_diagnostic.SA1114.severity = suggestion
+
+dotnet_diagnostic.SA1115.severity = none
+
+# Split parameters should start on line after declaration
+dotnet_diagnostic.SA1116.severity = suggestion
+
+# Parameters should be on same line or separate lines
+dotnet_diagnostic.SA1117.severity = suggestion
+
+dotnet_diagnostic.SA1118.severity = none
+
+dotnet_diagnostic.SA1119.severity = none
+
+# Comments should contain text
+dotnet_diagnostic.SA1120.severity = suggestion
+
+dotnet_diagnostic.SA1121.severity = none
+
+# Use string.Empty for empty strings
+dotnet_diagnostic.SA1122.severity = none
+
+# Region should not be located within a code element
+dotnet_diagnostic.SA1123.severity = suggestion
+
+dotnet_diagnostic.SA1124.severity = none
+
+# Use shorthand for nullable types
+dotnet_diagnostic.SA1125.severity = warning
+
+# Generic type constraints should be on their own line
+dotnet_diagnostic.SA1127.severity = suggestion
+
+# Put constructor initializers on their own line
+dotnet_diagnostic.SA1128.severity = suggestion
+
+dotnet_diagnostic.SA1129.severity = none
+
+# Use lambda syntax
+dotnet_diagnostic.SA1130.severity = suggestion
+
+# Constant values should appear on the right-hand side of comparisons
+dotnet_diagnostic.SA1131.severity = suggestion
+
+# Do not combine fields
+dotnet_diagnostic.SA1132.severity = warning
+
+# Do not combine attributes
+dotnet_diagnostic.SA1133.severity = warning
+
+# Each attribute should be placed on its own line of code
+dotnet_diagnostic.SA1134.severity = warning
+
+# Using directive should be qualified
+dotnet_diagnostic.SA1135.severity = warning
+
+# Enum values should be on separate lines
+dotnet_diagnostic.SA1136.severity = suggestion
+
+# Elements should have the same indentation
+dotnet_diagnostic.SA1137.severity = suggestion
+
+dotnet_diagnostic.SA1139.severity = none
+
+dotnet_diagnostic.SA1200.severity = none
+
+# Elements should appear in the correct order
+dotnet_diagnostic.SA1201.severity = suggestion
+
+# Elements should be ordered by access
+dotnet_diagnostic.SA1202.severity = suggestion
+
+# Constants should appear before fields
+dotnet_diagnostic.SA1203.severity = suggestion
+
+# Static elements should appear before instance elements
+dotnet_diagnostic.SA1204.severity = suggestion
+
+dotnet_diagnostic.SA1205.severity = none
+
+dotnet_diagnostic.SA1206.severity = none
+
+# Using directive ordering
+dotnet_diagnostic.SA1208.severity = suggestion
+
+# Using alias directives should be placed after all using namespace directives
+dotnet_diagnostic.SA1209.severity = suggestion
+
+# Using directives should be ordered alphabetically by the namespaces
+dotnet_diagnostic.SA1210.severity = suggestion
+
+# Using alias directive ordering
+dotnet_diagnostic.SA1211.severity = suggestion
+
+dotnet_diagnostic.SA1212.severity = none
+
+# Readonly fields should appear before non-readonly fields
+dotnet_diagnostic.SA1214.severity = suggestion
+
+# Using static directives should be placed at the correct location
+dotnet_diagnostic.SA1216.severity = warning
+
+# The using static directives within a C# code file are not sorted alphabetically by full type name.
+dotnet_diagnostic.SA1217.severity = suggestion
+
+# Element should begin with an uppercase letter
+dotnet_diagnostic.SA1300.severity = suggestion
+
+# Interface names should begin with I
+dotnet_diagnostic.SA1302.severity = warning
+
+# Const field names should begin with upper-case letter
+dotnet_diagnostic.SA1303.severity = suggestion
+
+# Non-private readonly fields should begin with upper-case letter
+dotnet_diagnostic.SA1304.severity = suggestion
+
+# Field should begin with lower-case letter
+dotnet_diagnostic.SA1306.severity = suggestion
+
+dotnet_diagnostic.SA1307.severity = none
+
+# Field should not begin with the prefix 's_'
+dotnet_diagnostic.SA1308.severity = suggestion
+
+dotnet_diagnostic.SA1309.severity = none
+
+dotnet_diagnostic.SA1310.severity = none
+
+# Static readonly fields should begin with upper-case letter
+dotnet_diagnostic.SA1311.severity = suggestion
+
+# Variable should begin with lower-case letter
+dotnet_diagnostic.SA1312.severity = suggestion
+
+# Parameter should begin with lower-case letter
+dotnet_diagnostic.SA1313.severity = suggestion
+
+dotnet_diagnostic.SA1314.severity = none
+
+# Tuple element names should use correct casing
+dotnet_diagnostic.SA1316.severity = suggestion
+
+dotnet_diagnostic.SA1400.severity = none
+
+# Fields should be private
+dotnet_diagnostic.SA1401.severity = suggestion
+
+# File may only contain a single type
+dotnet_diagnostic.SA1402.severity = suggestion
+
+# File may only contain a single namespace
+dotnet_diagnostic.SA1403.severity = suggestion
+
+# Code analysis suppression should have justification
+dotnet_diagnostic.SA1404.severity = suggestion
+
+# Debug.Assert should provide message text
+dotnet_diagnostic.SA1405.severity = suggestion
+
+# Arithmetic expressions should declare precedence
+dotnet_diagnostic.SA1407.severity = suggestion
+
+# Conditional expressions should declare precedence
+dotnet_diagnostic.SA1408.severity = warning
+
+dotnet_diagnostic.SA1410.severity = none
+
+dotnet_diagnostic.SA1411.severity = none
+
+# Use trailing comma in multi-line initializers
+dotnet_diagnostic.SA1413.severity = suggestion
+
+# Tuple types in signatures should have element names
+dotnet_diagnostic.SA1414.severity = suggestion
+
+# Braces for multi-line statements should not share line
+dotnet_diagnostic.SA1500.severity = suggestion
+
+# Statement should not be on a single line
+dotnet_diagnostic.SA1501.severity = suggestion
+
+# Element should not be on a single line
+dotnet_diagnostic.SA1502.severity = suggestion
+
+# Braces should not be omitted
+dotnet_diagnostic.SA1503.severity = suggestion
+
+# All accessors should be single-line or multi-line
+dotnet_diagnostic.SA1504.severity = warning
+
+# An opening brace should not be followed by a blank line
+dotnet_diagnostic.SA1505.severity = suggestion
+
+# Element documentation headers should not be followed by blank line
+dotnet_diagnostic.SA1506.severity = warning
+
+# Code should not contain multiple blank lines in a row
+dotnet_diagnostic.SA1507.severity = suggestion
+
+# A closing brace should not be preceded by a blank line
+dotnet_diagnostic.SA1508.severity = suggestion
+
+# Opening braces should not be preceded by blank line
+dotnet_diagnostic.SA1509.severity = warning
+
+# 'else' statement should not be preceded by a blank line
+dotnet_diagnostic.SA1510.severity = warning
+
+# Single-line comments should not be followed by blank line
+dotnet_diagnostic.SA1512.severity = suggestion
+
+# Closing brace should be followed by blank line
+dotnet_diagnostic.SA1513.severity = suggestion
+
+# Element documentation header should be preceded by blank line
+dotnet_diagnostic.SA1514.severity = suggestion
+
+# Single-line comment should be preceded by blank line
+dotnet_diagnostic.SA1515.severity = suggestion
+
+# Elements should be separated by blank line
+dotnet_diagnostic.SA1516.severity = suggestion
+
+dotnet_diagnostic.SA1517.severity = none
+
+# Code should not contain blank lines at the end of the file
+dotnet_diagnostic.SA1518.severity = warning
+
+# Braces should not be omitted from multi-line child statement
+dotnet_diagnostic.SA1519.severity = warning
+
+# Use braces consistently
+dotnet_diagnostic.SA1520.severity = suggestion
+
+dotnet_diagnostic.SA1600.severity = none
+
+# Partial elements should be documented
+dotnet_diagnostic.SA1601.severity = suggestion
+
+# Enumeration items should be documented
+dotnet_diagnostic.SA1602.severity = suggestion
+
+# Element documentation should have summary
+dotnet_diagnostic.SA1604.severity = suggestion
+
+# Partial element documentation should have summary
+dotnet_diagnostic.SA1605.severity = suggestion
+
+# Element documentation should have summary text
+dotnet_diagnostic.SA1606.severity = suggestion
+
+# Element documentation should not have default summary
+dotnet_diagnostic.SA1608.severity = suggestion
+
+# Property documentation should have value text
+dotnet_diagnostic.SA1610.severity = suggestion
+
+# The documentation for parameter 'message' is missing
+dotnet_diagnostic.SA1611.severity = suggestion
+
+# The parameter documentation is at incorrect position
+dotnet_diagnostic.SA1612.severity = suggestion
+
+# Element parameter documentation should have text
+dotnet_diagnostic.SA1614.severity = suggestion
+
+dotnet_diagnostic.SA1615.severity = none
+
+# Element return value documentation should have text
+dotnet_diagnostic.SA1616.severity = suggestion
+
+dotnet_diagnostic.SA1617.severity = none
+
+# The documentation for type parameter is missing
+dotnet_diagnostic.SA1618.severity = suggestion
+
+# The documentation for type parameter is missing
+dotnet_diagnostic.SA1619.severity = suggestion
+
+# Generic type parameter documentation should have text
+dotnet_diagnostic.SA1622.severity = suggestion
+
+# Property documentation text
+dotnet_diagnostic.SA1623.severity = suggestion
+
+# Because the property only contains a visible get accessor, the documentation summary text should begin with 'Gets'
+dotnet_diagnostic.SA1624.severity = suggestion
+
+dotnet_diagnostic.SA1625.severity = none
+
+# Single-line comments should not use documentation style slashes
+dotnet_diagnostic.SA1626.severity = suggestion
+
+# The documentation text within the \'exception\' tag should not be empty
+dotnet_diagnostic.SA1627.severity = suggestion
+
+# Documentation text should end with a period
+dotnet_diagnostic.SA1629.severity = suggestion
+
+# File should have header
+dotnet_diagnostic.SA1633.severity = suggestion
+
+# Constructor summary documentation should begin with standard text
+dotnet_diagnostic.SA1642.severity = suggestion
+
+# Destructor summary documentation should begin with standard text
+dotnet_diagnostic.SA1643.severity = suggestion
+
+# File name should match first type name
+dotnet_diagnostic.SA1649.severity = suggestion
+
+dotnet_diagnostic.SA1652.severity = none

--- a/build/common.props
+++ b/build/common.props
@@ -43,6 +43,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
     <PackageReference Include="AsyncFixer" Version="1.5.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
+	<PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406" PrivateAssets="all"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This really depends on the core team on exceptionless and what rules they want to keep. I have pulled in the rules used by MSBuild which seemed reasonable.
https://github.com/dotnet/msbuild/pull/5656

Generally with a change like this, the analysers are set to suggestions and moved to warnings or error once all instances are fixed. Each code analysis rule would be fixed in an separate PR. So this PR should be used to establish a list of rules to work against.