### PR TITLE
bump timeout higher, value shouldn't matter unless latch isn't triggered

### DIFF
--- a/test/Exceptionless.Tests/Storage/PersistedDictionaryTests.cs
+++ b/test/Exceptionless.Tests/Storage/PersistedDictionaryTests.cs
@@ -36,7 +36,7 @@ namespace Exceptionless.Tests.Storage {
 
             dict["test"] = "test";
             Assert.Equal(11, dict.Count);
-            success = latch.Wait(500);
+            success = latch.Wait(5000);
             Assert.True(success, "Failed to save dictionary.");
             Assert.True(storage.Exists("test.json"));
         }

--- a/test/Exceptionless.Tests/Storage/PersistedDictionaryTests.cs
+++ b/test/Exceptionless.Tests/Storage/PersistedDictionaryTests.cs
@@ -36,7 +36,7 @@ namespace Exceptionless.Tests.Storage {
 
             dict["test"] = "test";
             Assert.Equal(11, dict.Count);
-            success = latch.Wait(5000);
+            success = latch.Wait(1000);
             Assert.True(success, "Failed to save dictionary.");
             Assert.True(storage.Exists("test.json"));
         }

--- a/test/Exceptionless.Tests/Utility/CountDownLatch.cs
+++ b/test/Exceptionless.Tests/Utility/CountDownLatch.cs
@@ -12,7 +12,7 @@ namespace Exceptionless.Tests.Utility {
 
         public void Reset(int count) {
             if (count < 0)
-                throw new ArgumentOutOfRangeException();
+                throw new ArgumentOutOfRangeException(nameof(count));
             _remaining = count;
             _event = new ManualResetEventSlim(false);
             if (_remaining == 0)


### PR DESCRIPTION
fixes #275

An excessive value for the wait timeout on the second call should not matter, but will help if there is some sort of issue in saving which blows out the time. This value can be reduced if the point of the test is to make sure the save happens in a timely manner.