### PR TITLE
Change System.Net.Http Framework Reference to PackageReference.

### DIFF
--- a/src/Exceptionless/Exceptionless.csproj
+++ b/src/Exceptionless/Exceptionless.csproj
@@ -39,6 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Reflection.Metadata" Version="6.0.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
@@ -51,8 +52,6 @@
     <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />

--- a/src/Exceptionless/Submission/DefaultSubmissionClient.cs
+++ b/src/Exceptionless/Submission/DefaultSubmissionClient.cs
@@ -132,19 +132,11 @@ namespace Exceptionless.Submission {
         }
 
         protected virtual HttpClient CreateHttpClient(ExceptionlessConfiguration config) {
-#if NET45
-            var handler = new WebRequestHandler { UseDefaultCredentials = true };
-#else
             var handler = new HttpClientHandler { UseDefaultCredentials = true };
-#endif
 
             var callback = config.ServerCertificateValidationCallback;
             if (callback != null) {
-#if NET45
-                handler.ServerCertificateValidationCallback = (s,c,ch,p) => Validate(s,c,ch,p,callback);
-#else
                 handler.ServerCertificateCustomValidationCallback = (m,c,ch,p) => Validate(m,c,ch,p,callback);
-#endif
             }
 
             if (handler.SupportsAutomaticDecompression)
@@ -165,17 +157,10 @@ namespace Exceptionless.Submission {
             return client;
         }
 
-#if NET45
-        private static bool Validate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors, Func<CertificateData, bool> callback) {
-            var certData = new CertificateData(sender, certificate, chain, sslPolicyErrors);
-            return callback(certData);
-        }
-#else
         private static bool Validate(HttpRequestMessage httpRequestMessage, X509Certificate2 certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors, Func<CertificateData, bool> callback) {
             var certData = new CertificateData(httpRequestMessage, certificate, chain, sslPolicyErrors);
             return callback(certData);
         }
-#endif
 
         private string GetResponseMessage(HttpResponseMessage response) {
             if (response.IsSuccessStatusCode)


### PR DESCRIPTION
Remove WebRequestHandler.
HttpClientHandler can do all the work with help of new System.Net.Http.