### PR TITLE
Add Windows environment info collector to the WPF platform

### DIFF
--- a/src/Platforms/Exceptionless.Wpf/Exceptionless.Wpf.csproj
+++ b/src/Platforms/Exceptionless.Wpf/Exceptionless.Wpf.csproj
@@ -44,4 +44,8 @@
     <Resource Include="Images\ErrorFeedback.png" />
     <Folder Include="Properties\" />
   </ItemGroup>
+
+  <ItemGroup Label="Source Links">
+    <Compile Include="..\Exceptionless.Windows\ExceptionlessWindowsEnvironmentInfoCollector.cs" Link="ExceptionlessWindowsEnvironmentInfoCollector.cs" />
+  </ItemGroup>
 </Project>

--- a/src/Platforms/Exceptionless.Wpf/ExceptionlessWpfExtensions.cs
+++ b/src/Platforms/Exceptionless.Wpf/ExceptionlessWpfExtensions.cs
@@ -6,12 +6,13 @@ using Exceptionless.Dependency;
 using Exceptionless.Dialogs;
 using Exceptionless.Logging;
 using Exceptionless.Plugins.Default;
+using Exceptionless.Services;
 using Exceptionless.Wpf.Extensions;
 
 namespace Exceptionless {
     public static class ExceptionlessWpfExtensions {
         /// <summary>
-        /// Reads configuration settings, configures various plugins and wires up to platform specific exception handlers. 
+        /// Reads configuration settings, configures various plugins and wires up to platform specific exception handlers.
         /// </summary>
         /// <param name="client">The ExceptionlessClient.</param>
         /// <param name="showDialog">Controls whether a dialog is shown when an unhandled exception occurs.</param>
@@ -20,8 +21,9 @@ namespace Exceptionless {
                 throw new ArgumentNullException(nameof(client));
 
             client.Configuration.AddPlugin<SetEnvironmentUserPlugin>();
+            client.Configuration.Resolver.Register<IEnvironmentInfoCollector, ExceptionlessWindowsEnvironmentInfoCollector>();
             client.Startup();
-            
+
             client.RegisterApplicationDispatcherUnhandledExceptionHandler();
 
             if (!showDialog)


### PR DESCRIPTION
Fixes #290 by add source link to `ExceptionslessWindowsEnvironmentInfoCollector` in the WPF platform project and registering that services to the dependency resolver.

              You should only need to use the Wpf client, code is shared between the clients. I'm trying to think if there is any reason we shouldn't be capturing that environment info in wpf. I can't think of any reason not to.. Would you mind submitting a pr to add a source link to that file in the wpf project and then adding a line to `client.Configuration.Resolver.Register<IEnvironmentInfoCollector, ExceptionlessWindowsEnvironmentInfoCollector>();` in register.

_Originally posted by @niemyjski in https://github.com/exceptionless/Exceptionless.Net/issues/290#issuecomment-1398800297_
            