### PR TITLE
ExceptionlessTarget - ApiKey and ServerUrl and Message and UserIdentity with Layout support

### DIFF
--- a/src/Platforms/Exceptionless.NLog/ExceptionlessClientExtensions.cs
+++ b/src/Platforms/Exceptionless.NLog/ExceptionlessClientExtensions.cs
@@ -74,7 +74,7 @@ namespace Exceptionless.NLog {
             CreateFromLogEvent(client, ev).Submit();
         }
 
-        private static readonly HashSet<string> _ignoredEventProperties = new HashSet<string> {
+        private static readonly HashSet<string> _ignoredEventProperties = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
             "Tags",
             "ContextData"
         };

--- a/src/Platforms/Exceptionless.NLog/ExceptionlessClientExtensions.cs
+++ b/src/Platforms/Exceptionless.NLog/ExceptionlessClientExtensions.cs
@@ -8,6 +8,10 @@ using NLog;
 namespace Exceptionless.NLog {
     public static class ExceptionlessClientExtensions {
         public static EventBuilder CreateFromLogEvent(this ExceptionlessClient client, LogEventInfo ev) {
+            return CreateFromLogEvent(client, ev, ev.FormattedMessage);
+        }
+
+        public static EventBuilder CreateFromLogEvent(this ExceptionlessClient client, LogEventInfo ev, string formattedMessage) {
             if (client == null)
                 throw new ArgumentNullException(nameof(client));
 
@@ -20,10 +24,10 @@ namespace Exceptionless.NLog {
             builder.Target.Date = ev.TimeStamp;
             builder.SetSource(ev.LoggerName);
 
-            if (ev.Properties.Count > 0) {
+            if (ev.HasProperties) {
                 foreach (var property in ev.Properties) {
                     string propertyKey = property.Key.ToString();
-                    if (_ignoredEventProperties.Contains(propertyKey, StringComparer.OrdinalIgnoreCase))
+                    if (_ignoredEventProperties.Contains(propertyKey))
                         continue;
 
                     if (propertyKey.Equals("@value", StringComparison.OrdinalIgnoreCase)) {
@@ -53,8 +57,8 @@ namespace Exceptionless.NLog {
                 builder.SetType(Event.KnownTypes.Error);
             }
 
-            if (!String.IsNullOrWhiteSpace(ev.FormattedMessage))
-                builder.SetMessage(ev.FormattedMessage);
+            if (!String.IsNullOrWhiteSpace(formattedMessage))
+                builder.SetMessage(formattedMessage);
 
             var tags = ev.GetTags();
             if (tags != null)
@@ -70,10 +74,7 @@ namespace Exceptionless.NLog {
             CreateFromLogEvent(client, ev).Submit();
         }
 
-        private static readonly List<string> _ignoredEventProperties = new List<string> {
-            "CallerFilePath",
-            "CallerMemberName",
-            "CallerLineNumber",
+        private static readonly HashSet<string> _ignoredEventProperties = new HashSet<string> {
             "Tags",
             "ContextData"
         };

--- a/src/Platforms/Exceptionless.NLog/ExceptionlessTarget.cs
+++ b/src/Platforms/Exceptionless.NLog/ExceptionlessTarget.cs
@@ -13,6 +13,8 @@ namespace Exceptionless.NLog {
         public Layout ApiKey { get; set; }
         public Layout ServerUrl { get; set; }
         public Layout UserIdentity { get; set; }
+        public Layout UserIdentityName { get; set; }
+        public Layout UserIdentityEmail { get; set; }
 
         [ArrayParameter(typeof(ExceptionlessField), "field")]
         public IList<ExceptionlessField> Fields { get; set; }
@@ -50,8 +52,12 @@ namespace Exceptionless.NLog {
             var builder = _client.CreateFromLogEvent(logEvent, formattedMessage);
 
             var userIdentity = RenderLogEvent(UserIdentity, logEvent);
-            if (!String.IsNullOrWhiteSpace(userIdentity))
-                builder.Target.SetUserIdentity(userIdentity);
+            var userIdentityName = RenderLogEvent(UserIdentityName, logEvent);
+            builder.Target.SetUserIdentity(userIdentity, userIdentityName);
+
+            var userIdentityEmail = RenderLogEvent(UserIdentityEmail, logEvent);
+            if (!String.IsNullOrWhiteSpace(userIdentityEmail))
+                builder.SetUserDescription(userIdentityEmail, userIdentityName);
 
             foreach (var field in Fields) {
                 var renderedField = RenderLogEvent(field.Layout, logEvent);

--- a/src/Platforms/Exceptionless.NLog/ExceptionlessTarget.cs
+++ b/src/Platforms/Exceptionless.NLog/ExceptionlessTarget.cs
@@ -12,7 +12,6 @@ namespace Exceptionless.NLog {
 
         public Layout ApiKey { get; set; }
         public Layout ServerUrl { get; set; }
-        public Layout ReferenceId { get; set; }
         public Layout UserIdentity { get; set; }
 
         [ArrayParameter(typeof(ExceptionlessField), "field")]
@@ -49,10 +48,6 @@ namespace Exceptionless.NLog {
 
             var formattedMessage = RenderLogEvent(Layout, logEvent);
             var builder = _client.CreateFromLogEvent(logEvent, formattedMessage);
-
-            var referenceId = RenderLogEvent(ReferenceId, logEvent);
-            if (!String.IsNullOrWhiteSpace(referenceId))
-                builder.SetReferenceId(referenceId);
 
             var userIdentity = RenderLogEvent(UserIdentity, logEvent);
             if (!String.IsNullOrWhiteSpace(userIdentity))

--- a/src/Platforms/Exceptionless.NLog/ExceptionlessTarget.cs
+++ b/src/Platforms/Exceptionless.NLog/ExceptionlessTarget.cs
@@ -14,7 +14,6 @@ namespace Exceptionless.NLog {
         public Layout ServerUrl { get; set; }
         public Layout UserIdentity { get; set; }
         public Layout UserIdentityName { get; set; }
-        public Layout UserIdentityEmail { get; set; }
 
         [ArrayParameter(typeof(ExceptionlessField), "field")]
         public IList<ExceptionlessField> Fields { get; set; }
@@ -54,10 +53,6 @@ namespace Exceptionless.NLog {
             var userIdentity = RenderLogEvent(UserIdentity, logEvent);
             var userIdentityName = RenderLogEvent(UserIdentityName, logEvent);
             builder.Target.SetUserIdentity(userIdentity, userIdentityName);
-
-            var userIdentityEmail = RenderLogEvent(UserIdentityEmail, logEvent);
-            if (!String.IsNullOrWhiteSpace(userIdentityEmail))
-                builder.SetUserDescription(userIdentityEmail, userIdentityName);
 
             foreach (var field in Fields) {
                 var renderedField = RenderLogEvent(field.Layout, logEvent);

--- a/src/Platforms/Exceptionless.NLog/LogEventBuilderExtensions.cs
+++ b/src/Platforms/Exceptionless.NLog/LogEventBuilderExtensions.cs
@@ -90,8 +90,8 @@ namespace Exceptionless.NLog {
         }
 
         internal static HashSet<string> GetTags(this LogEventInfo ev) {
-            if (ev.Properties.ContainsKey(Tags) && ev.Properties[Tags] is HashSet<string>)
-                return (HashSet<string>)ev.Properties[Tags];
+            if (ev.HasProperties && ev.Properties.TryGetValue(Tags, out var tags))
+                return tags as HashSet<string>;
 
             return null;
         }
@@ -109,8 +109,8 @@ namespace Exceptionless.NLog {
         }
 
         internal static IDictionary<string, object> GetContextData(this LogEventInfo ev) {
-            if (ev.Properties.ContainsKey(ContextData) && ev.Properties[ContextData] is IDictionary<string, object>)
-                return (IDictionary<string, object>)ev.Properties[ContextData];
+            if (ev.HasProperties && ev.Properties.TryGetValue(ContextData, out var contextData))
+                return contextData as IDictionary<string, object>;
 
             return null;
         }

--- a/src/Platforms/Exceptionless.NLog/NLogExceptionlessLog.cs
+++ b/src/Platforms/Exceptionless.NLog/NLogExceptionlessLog.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Exceptionless.Logging;
 using NLog;
-using NLog.Fluent;
 using LogLevel = Exceptionless.Logging.LogLevel;
 
 namespace Exceptionless.NLog {
@@ -19,35 +18,35 @@ namespace Exceptionless.NLog {
             if (LogLevel.Error < MinimumLogLevel)
                 return;
             
-            _logger.ForErrorEvent().Message(message).LoggerName(source).Exception(exception).Log();
+            _logger.ForErrorEvent().Message(message).LoggerName(source).Exception(exception).Log(typeof(NLogExceptionlessLog));
         }
 
         public void Info(string message, string source = null) {
             if (LogLevel.Info < MinimumLogLevel)
                 return;
             
-            _logger.ForInfoEvent().Message(message).LoggerName(source).Log();
+            _logger.ForInfoEvent().Message(message).LoggerName(source).Log(typeof(NLogExceptionlessLog));
         }
 
         public void Debug(string message, string source = null) {
             if (LogLevel.Debug < MinimumLogLevel)
                 return;
             
-            _logger.ForDebugEvent().Message(message).LoggerName(source).Log();
+            _logger.ForDebugEvent().Message(message).LoggerName(source).Log(typeof(NLogExceptionlessLog));
         }
 
         public void Warn(string message, string source = null) {
             if (LogLevel.Warn < MinimumLogLevel)
                 return;
             
-            _logger.ForWarnEvent().Message(message).LoggerName(source).Log();
+            _logger.ForWarnEvent().Message(message).LoggerName(source).Log(typeof(NLogExceptionlessLog));
         }
 
         public void Trace(string message, string source = null) {
             if (LogLevel.Trace < MinimumLogLevel)
                 return;
             
-            _logger.ForTraceEvent().Message(message).LoggerName(source).Log();
+            _logger.ForTraceEvent().Message(message).LoggerName(source).Log(typeof(NLogExceptionlessLog));
         }
 
         public void Flush() { }

--- a/src/Platforms/Exceptionless.NLog/readme.txt
+++ b/src/Platforms/Exceptionless.NLog/readme.txt
@@ -36,7 +36,7 @@ minimum log level that will be used until the client retrieves settings from the
 <?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <targets>
+  <targets async="true">
     <target type="Exceptionless, Exceptionless.NLog" name="exceptionless" apiKey="API_KEY_HERE">
       <field name="host" layout="${machinename}" />
       <field name="process" layout="${processname}" />

--- a/src/Platforms/Exceptionless.NLog/readme.txt
+++ b/src/Platforms/Exceptionless.NLog/readme.txt
@@ -36,12 +36,11 @@ minimum log level that will be used until the client retrieves settings from the
 <?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <targets async="true">
-    <target xsi:type="Exceptionless, Exceptionless.NLog" name="exceptionless" apiKey="API_KEY_HERE">
+  <targets>
+    <target type="Exceptionless, Exceptionless.NLog" name="exceptionless" apiKey="API_KEY_HERE">
       <field name="host" layout="${machinename}" />
-      <field name="identity" layout="${identity}" />
-      <field name="windows-identity" layout="${windows-identity:userName=True:domain=False}" />
       <field name="process" layout="${processname}" />
+      <field name="user" layout="${environment-user}" />
     </target>
   </targets>
 


### PR DESCRIPTION
Resolves #297 and resolves #296

```xml
    <target type="Exceptionless, Exceptionless.NLog" name="exceptionless"
            apiKey="API_KEY_HERE"
            userIdentity="${aspnet-user-identity}"
            userIdentityName="${aspnet-user-claim:ClaimTypes.Name}">
      <field name="host" layout="${hostname}" />
      <field name="process" layout="${processname}" />
      <field name="user" layout="${environment-user}" />
    </target>
```
[${aspnet-user-identity}](https://github.com/NLog/NLog/wiki/AspNetUserIdentity-layout-renderer) comes from [NLog.Web.AspNetCore](https://www.nuget.org/packages/NLog.Web.AspNetCore)-nuget-package . See also: https://nlog-project.org/config/?tab=layout-renderers