### PR TITLE
Fixed issues with async event handlers and improved trace logging

### DIFF
--- a/src/Exceptionless/ExceptionlessClient.cs
+++ b/src/Exceptionless/ExceptionlessClient.cs
@@ -148,6 +148,7 @@ namespace Exceptionless {
                 }
             }
 
+            _log.Value.Info(typeof(ExceptionlessClient), "Processing event queue");
             return _queue.Value.ProcessAsync();
         }
 

--- a/src/Exceptionless/Extensions/ExceptionlessClientExtensions.cs
+++ b/src/Exceptionless/Extensions/ExceptionlessClientExtensions.cs
@@ -65,6 +65,7 @@ namespace Exceptionless {
             }
 
             log.Info(typeof(ExceptionlessClient), "Shutdown finished");
+            log.Flush();
         }
 
 #region Submission Extensions
@@ -384,6 +385,7 @@ namespace Exceptionless.Extensions {
                         }
 
                         log.Info(typeof(ExceptionlessClient), "AppDomain.CurrentDomain.UnhandledException finished");
+                        log.Flush();
                     } catch (Exception ex) {
                         log.Error(typeof(ExceptionlessClientExtensions), ex, String.Concat("An error occurred while processing AppDomain unhandled exception: ", ex.Message));
                     }
@@ -428,6 +430,7 @@ namespace Exceptionless.Extensions {
                         }
 
                         log.Info(typeof(ExceptionlessClient), "ProcessExit finished");
+                        log.Flush();
                     } catch (Exception ex) {
                         log.Error(typeof(ExceptionlessClientExtensions), ex, String.Concat("An error occurred while processing process exit: ", ex.Message));
                     }

--- a/src/Exceptionless/Submission/DefaultSubmissionClient.cs
+++ b/src/Exceptionless/Submission/DefaultSubmissionClient.cs
@@ -43,7 +43,7 @@ namespace Exceptionless.Submission {
                 _client.Value.AddAuthorizationHeader(config.ApiKey);
                 response = await _client.Value.PostAsync(url, content).ConfigureAwait(false);
             } catch (Exception ex) {
-                return new SubmissionResponse(500, exception: ex);
+                return new SubmissionResponse(500, message: ex.GetMessage(), exception: ex);
             }
 
             if (Int32.TryParse(GetSettingsVersionHeader(response.Headers), out int settingsVersion))
@@ -75,7 +75,7 @@ namespace Exceptionless.Submission {
                 _client.Value.AddAuthorizationHeader(config.ApiKey);
                 response = await _client.Value.PostAsync(url, content).ConfigureAwait(false);
             } catch (Exception ex) {
-                return new SubmissionResponse(500, exception: ex);
+                return new SubmissionResponse(500, message: ex.GetMessage(), exception: ex);
             }
 
             if (Int32.TryParse(GetSettingsVersionHeader(response.Headers), out int settingsVersion))
@@ -100,8 +100,7 @@ namespace Exceptionless.Submission {
                 _client.Value.AddAuthorizationHeader(config.ApiKey);
                 response = await _client.Value.GetAsync(url).ConfigureAwait(false);
             } catch (Exception ex) {
-                var message = String.Concat("Unable to retrieve configuration settings. Exception: ", ex.GetMessage());
-                return new SettingsResponse(false, message: message);
+                return new SettingsResponse(false, message: ex.GetMessage(), exception: ex);
             }
 
             if (response != null && response.StatusCode == HttpStatusCode.NotModified)
@@ -109,7 +108,7 @@ namespace Exceptionless.Submission {
 
             if (response == null || response.StatusCode != HttpStatusCode.OK) {
                 string message = await GetResponseMessageAsync(response).ConfigureAwait(false);
-                return new SettingsResponse(false, message: String.Concat("Unable to retrieve configuration settings: ", message));
+                return new SettingsResponse(false, message: message);
             }
 
             string json = await GetResponseTextAsync(response).ConfigureAwait(false);
@@ -130,7 +129,7 @@ namespace Exceptionless.Submission {
                 await _client.Value.GetAsync(url).ConfigureAwait(false);
             } catch (Exception ex) {
                 var log = config.Resolver.GetLog();
-                log.Error(String.Concat("Error submitting heartbeat: ", ex.GetMessage()));
+                log.Error(String.Concat("Error submitting heartbeat: ", ex.GetMessage()), exception: ex);
             }
         }
 


### PR DESCRIPTION
Found a case where process exit and unhandled event handlers will return early due to being marked async causing early exit. This could potentially (unlikely) cause a dead lock on shutdown due to GetAwaiter().GetResult() but benefits greatly outweigh (I was also unable to cause this scenario with a deadlock)

Also, we may want to consider having our internal trace loggers implement disposable so flush is called (may be happing today by ioc but flush and dispose is not called by default)

I also greatly improved logging of the client to give more visibility of what is happening instead of only logging on error:

```
2023-05-09 08:01:44.3824 Info  ExceptionlessClient: Startup called ApiKey=MY_API_KEY ServerUrl=https://localhost:5000
2023-05-09 08:01:44.5095 Info  ExceptionlessClient: Startup finished
2023-05-09 08:01:49.7881 Info  ExceptionlessClient: ProcessExit called
2023-05-09 08:01:49.7884 Info  ExceptionlessClient: Processing event queue
2023-05-09 08:01:49.7888 Info  ExceptionlessClient: Sending Session End Heartbeat
2023-05-09 08:01:49.8143 Info  DefaultEventQueue: Sent 1 events to "https://localhost:5000".
2023-05-09 08:01:50.0305 Info  ExceptionlessClient: ProcessExit finished
```

