### PR TITLE
Add support for IConfiguration when using netstandard.

### DIFF
--- a/src/Exceptionless/Exceptionless.csproj
+++ b/src/Exceptionless/Exceptionless.csproj
@@ -34,6 +34,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'" Label="Package References">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>

--- a/src/Platforms/Exceptionless.Extensions.Hosting/ExceptionlessExtensions.cs
+++ b/src/Platforms/Exceptionless.Extensions.Hosting/ExceptionlessExtensions.cs
@@ -1,10 +1,5 @@
 using System;
-using System.Reflection;
-using Exceptionless.Dependency;
 using Exceptionless.Extensions.Hosting;
-using Exceptionless.Logging;
-using Exceptionless.Serializer;
-using Exceptionless.Storage;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -82,82 +77,6 @@ namespace Exceptionless {
 
                 return client;
             });
-        }
-
-        /// <summary>
-        /// Sets the configuration from .net configuration settings.
-        /// </summary>
-        /// <param name="config">The configuration object you want to apply the settings to.</param>
-        /// <param name="settings">The configuration settings</param>
-        public static void ReadFromConfiguration(this ExceptionlessConfiguration config, IConfiguration settings) {
-            if (config == null)
-                throw new ArgumentNullException(nameof(config));
-
-            if (settings == null)
-                throw new ArgumentNullException(nameof(settings));
-
-            var section = settings.GetSection("Exceptionless");
-            if (Boolean.TryParse(section["Enabled"], out bool enabled) && !enabled)
-                config.Enabled = false;
-            
-            string apiKey = section["ApiKey"];
-            if (!String.IsNullOrEmpty(apiKey) && apiKey != "API_KEY_HERE")
-                config.ApiKey = apiKey;
-
-            string serverUrl = section["ServerUrl"];
-            if (!String.IsNullOrEmpty(serverUrl))
-                config.ServerUrl = serverUrl;
-            
-            if (TimeSpan.TryParse(section["QueueMaxAge"], out var queueMaxAge))
-                config.QueueMaxAge = queueMaxAge;
-
-            if (Int32.TryParse(section["QueueMaxAttempts"], out int queueMaxAttempts))
-                config.QueueMaxAttempts = queueMaxAttempts;
-            
-            string storagePath = section["StoragePath"];
-            if (!String.IsNullOrEmpty(storagePath))
-                config.Resolver.Register(typeof(IObjectStorage), () => new FolderObjectStorage(config.Resolver, storagePath));
-
-            string storageSerializer = section["StorageSerializer"];
-            if (!String.IsNullOrEmpty(storageSerializer)) {
-                try {
-                    var serializerType = Type.GetType(storageSerializer);
-                    if (!typeof(IStorageSerializer).GetTypeInfo().IsAssignableFrom(serializerType)) {
-                        config.Resolver.GetLog().Error(typeof(ExceptionlessConfigurationExtensions), $"The storage serializer {storageSerializer} does not implemented interface {typeof(IStorageSerializer)}.");
-                    } else {
-                        config.Resolver.Register(typeof(IStorageSerializer), serializerType);
-                    }
-                } catch (Exception ex) {
-                    config.Resolver.GetLog().Error(typeof(ExceptionlessConfigurationExtensions), ex, $"The storage serializer {storageSerializer} type could not be resolved: ${ex.Message}");
-                }
-            }
-            
-            if (Boolean.TryParse(section["EnableLogging"], out bool enableLogging) && enableLogging) {
-                string logPath = section["LogPath"];
-                if (!String.IsNullOrEmpty(logPath))
-                    config.UseFileLogger(logPath);
-                else if (!String.IsNullOrEmpty(storagePath))
-                    config.UseFileLogger(System.IO.Path.Combine(storagePath, "exceptionless.log"));
-            }
-            
-            if (Boolean.TryParse(section["IncludePrivateInformation"], out bool includePrivateInformation) && !includePrivateInformation)
-                config.IncludePrivateInformation = false;
-
-            if (Boolean.TryParse(section["ProcessQueueOnCompletedRequest"], out bool processQueueOnCompletedRequest) && processQueueOnCompletedRequest)
-                config.ProcessQueueOnCompletedRequest = true;
-
-            foreach (var tag in section.GetSection("DefaultTags").GetChildren())
-                config.DefaultTags.Add(tag.Value);
-            
-            foreach (var data in section.GetSection("DefaultData").GetChildren())
-                if (data.Value != null)
-                    config.DefaultData[data.Key] = data.Value;
-            
-            foreach (var setting in section.GetSection("Settings").GetChildren())
-                if (setting.Value != null)
-                    config.Settings[setting.Key] = setting.Value;
-            
-            // TODO: Support Registrations
         }
     }
 }


### PR DESCRIPTION
This allows for other consumers using .NET Core clients like WPF to use IConfiguration.

```
ExceptionlessClient.Default.Configuration.ReadFromConfiguration(config);
ExceptionlessClient.Default.Register();
```

We are taking a dep on the LTS abstraction, it would be great to automatically read from configuration but:
1. We would have to take out much larger dependencies..
2. We wouldn't know your naming scheme of your configuration files...