### PR TITLE
Fixed a bug where Application.ThreadException, HttpApplication.Error, Application.Current.DispatcherUnhandledException may not be logged

### DIFF
--- a/src/Exceptionless/Extensions/ExceptionlessClientExtensions.cs
+++ b/src/Exceptionless/Extensions/ExceptionlessClientExtensions.cs
@@ -6,8 +6,6 @@ using Exceptionless.Plugins;
 using Exceptionless.Logging;
 using Exceptionless.Models;
 
-#pragma warning disable AsyncFixer03
-
 namespace Exceptionless {
     public static class ExceptionlessClientExtensions {
         /// <summary>
@@ -385,9 +383,10 @@ namespace Exceptionless.Extensions {
                         }
 
                         log.Info(typeof(ExceptionlessClient), "AppDomain.CurrentDomain.UnhandledException finished");
-                        log.Flush();
                     } catch (Exception ex) {
                         log.Error(typeof(ExceptionlessClientExtensions), ex, String.Concat("An error occurred while processing AppDomain unhandled exception: ", ex.Message));
+                    } finally {
+                        log.Flush();    
                     }
                 };
             }
@@ -430,9 +429,10 @@ namespace Exceptionless.Extensions {
                         }
 
                         log.Info(typeof(ExceptionlessClient), "ProcessExit finished");
-                        log.Flush();
                     } catch (Exception ex) {
                         log.Error(typeof(ExceptionlessClientExtensions), ex, String.Concat("An error occurred while processing process exit: ", ex.Message));
+                    } finally {
+                        log.Flush();
                     }
                 };
             }

--- a/src/Platforms/Exceptionless.Wpf/ExceptionlessClientExtensions.cs
+++ b/src/Platforms/Exceptionless.Wpf/ExceptionlessClientExtensions.cs
@@ -4,8 +4,6 @@ using Exceptionless.Dependency;
 using Exceptionless.Plugins;
 using Exceptionless.Logging;
 
-#pragma warning disable AsyncFixer03
-
 namespace Exceptionless.Wpf.Extensions {
     public static class ExceptionlessClientExtensions {
         private static DispatcherUnhandledExceptionEventHandler _onApplicationDispatcherUnhandledException;
@@ -17,22 +15,30 @@ namespace Exceptionless.Wpf.Extensions {
             if (System.Windows.Application.Current == null)
                 return;
 
-            if (_onApplicationDispatcherUnhandledException == null)
-                _onApplicationDispatcherUnhandledException = async (sender, args) => {
-                    var contextData = new ContextData();
-                    contextData.MarkAsUnhandledError();
-                    contextData.SetSubmissionMethod("DispatcherUnhandledException");
-
-                    args.Exception.ToExceptionless(contextData, client).Submit();
+            if (_onApplicationDispatcherUnhandledException == null) {
+                _onApplicationDispatcherUnhandledException = (sender, args) => {
+                    var log = client.Configuration.Resolver.GetLog();
 
                     try {
+                        log.Info(typeof(ExceptionlessClient), "Application.Current.DispatcherUnhandledException called");
+
+                        var contextData = new ContextData();
+                        contextData.MarkAsUnhandledError();
+                        contextData.SetSubmissionMethod("DispatcherUnhandledException");
+
+                        args.Exception.ToExceptionless(contextData, client).Submit();
+
                         // process queue immediately since the app is about to exit.
-                        await client.ProcessQueueAsync().ConfigureAwait(false);
+                        client.ProcessQueueAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+
+                        log.Info(typeof(ExceptionlessClient), "Application.Current.DispatcherUnhandledException finished");
                     } catch (Exception ex) {
-                        var log = client.Configuration.Resolver.GetLog();
                         log.Error(typeof(ExceptionlessClientExtensions), ex, String.Concat("An error occurred while processing application dispatcher exception: ", ex.Message));
+                    } finally {
+                        log.Flush();
                     }
                 };
+            }
 
             try {
                 System.Windows.Application.Current.DispatcherUnhandledException -= _onApplicationDispatcherUnhandledException;


### PR DESCRIPTION
Also improved logging
```
2023-05-18 07:35:46.3627 Info  ExceptionlessClient: Startup finished
2023-05-18 07:35:51.7581 Info  ExceptionlessClient: Application.Current.DispatcherUnhandledException called
2023-05-18 07:35:57.5818 Info  ExceptionlessClient: Processing event queue
2023-05-18 07:35:57.8918 Info  DefaultEventQueue: Sent 1 events to "http://localhost".
2023-05-18 07:35:57.8927 Info  ExceptionlessClient: Application.Current.DispatcherUnhandledException finished
2023-05-18 07:35:58.8683 Info  ExceptionlessClient: AppDomain.CurrentDomain.UnhandledException called
2023-05-18 07:35:58.8703 Info  ErrorPlugin: Event submission cancelled by plugin: refid= type=error message=
2023-05-18 07:35:58.8704 Info  ExceptionlessClient: Event submission cancelled by event pipeline: refid= type=error message=
2023-05-18 07:35:58.8704 Info  ExceptionlessClient: Processing event queue
2023-05-18 07:35:58.8704 Info  ExceptionlessClient: AppDomain.CurrentDomain.UnhandledException finished
```