### PR TITLE
Remove Deprecated Microsoft.Extensions.PlatformAbstractions

### DIFF
--- a/src/Exceptionless/Exceptionless.csproj
+++ b/src/Exceptionless/Exceptionless.csproj
@@ -35,7 +35,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'" Label="Package References">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/Exceptionless/Plugins/Default/080_VersionPlugin.cs
+++ b/src/Exceptionless/Plugins/Default/080_VersionPlugin.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using System.Linq;
-using System.Reflection;
 using Exceptionless.Logging;
 using Exceptionless.Models;
+using Exceptionless.Utility;
 
 namespace Exceptionless.Plugins.Default {
     [Priority(80)]
@@ -40,10 +39,10 @@ namespace Exceptionless.Plugins.Default {
             if (_appVersionLoaded)
                 return _appVersion;
 
-            var entryAssembly = GetEntryAssembly(log);
+            var entryAssembly = AssemblyHelper.GetEntryAssembly(log);
 
             try {
-                string version = GetVersionFromAssembly(entryAssembly);
+                string version = AssemblyHelper.GetVersionFromAssembly(entryAssembly);
                 if (!String.IsNullOrEmpty(version)) {
                     _appVersion = version;
                     _appVersionLoaded = true;
@@ -54,80 +53,11 @@ namespace Exceptionless.Plugins.Default {
                 log.FormattedError(typeof(VersionPlugin), ex, "Unable to get version from loaded assemblies. Error: {0}", ex.Message);
             }
 
-#if NETSTANDARD2_0
-            try {
-                var platformService = Microsoft.Extensions.PlatformAbstractions.PlatformServices.Default;
-
-                _appVersion = platformService.Application.ApplicationVersion;
-                _appVersionLoaded = true;
-
-                return _appVersion;
-            } catch (Exception ex) {
-                log.FormattedError(typeof(VersionPlugin), ex, "Unable to get Platform Services instance. Error: {0}", ex.Message);
-            }
-#endif
-
             _appVersion = null;
             _appVersionLoaded = true;
 
             return null;
         }
 
-        private string GetVersionFromAssembly(Assembly assembly) {
-            if (assembly == null)
-                return null;
-
-            string version = assembly.GetInformationalVersion();
-            if (String.IsNullOrEmpty(version) || String.Equals(version, "0.0.0.0"))
-                version = assembly.GetFileVersion();
-
-            if (String.IsNullOrEmpty(version) || String.Equals(version, "0.0.0.0"))
-                version = assembly.GetVersion();
-
-            if (String.IsNullOrEmpty(version) || String.Equals(version, "0.0.0.0")) {
-                var assemblyName = assembly.GetAssemblyName();
-                version = assemblyName != null ? assemblyName.Version.ToString() : null;
-            }
-
-            return !String.IsNullOrEmpty(version) && !String.Equals(version, "0.0.0.0") ? version : null;
-        }
-
-        private Assembly GetEntryAssembly(IExceptionlessLog log) {
-            var entryAssembly = Assembly.GetEntryAssembly();
-            if (IsUserAssembly(entryAssembly))
-                return entryAssembly;
-
-            try {
-                var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(a => 
-                    !a.IsDynamic
-                    && a != typeof(ExceptionlessClient).GetTypeInfo().Assembly
-                    && a != GetType().GetTypeInfo().Assembly
-                    && a != typeof(object).GetTypeInfo().Assembly);
-
-                return assemblies.FirstOrDefault(a => IsUserAssembly(a));
-            } catch (Exception ex) {
-                log.FormattedError(typeof(VersionPlugin), ex, "Unable to get entry assembly. Error: {0}", ex.Message);
-            }
-
-            return null;
-        }
-
-        private bool IsUserAssembly(Assembly assembly) {
-            if (assembly == null)
-                return false;
-
-            if (!String.IsNullOrEmpty(assembly.FullName) && (assembly.FullName.StartsWith("System.") || assembly.FullName.StartsWith("Microsoft.")))
-                return false;
-
-            string company = assembly.GetCompany() ?? String.Empty;
-            string[] nonUserCompanies = new[] { "Exceptionless", "Microsoft" };
-            if (nonUserCompanies.Any(c => company.IndexOf(c, StringComparison.OrdinalIgnoreCase) >= 0))
-                return false;
-
-            if (assembly.FullName == typeof(ExceptionlessClient).GetTypeInfo().Assembly.FullName)
-                return false;
-
-            return true;
-        }
     }
 }

--- a/src/Exceptionless/Utility/AssemblyHelper.cs
+++ b/src/Exceptionless/Utility/AssemblyHelper.cs
@@ -10,6 +10,63 @@ namespace Exceptionless.Utility {
             return Assembly.GetEntryAssembly();
         }
 
+        public static Assembly GetEntryAssembly(IExceptionlessLog log) {
+            var entryAssembly = Assembly.GetEntryAssembly();
+            if (IsUserAssembly(entryAssembly))
+                return entryAssembly;
+
+            try {
+                var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(a =>
+                    !a.IsDynamic
+                    && a != typeof(ExceptionlessClient).GetTypeInfo().Assembly
+                    && a != typeof(object).GetTypeInfo().Assembly);
+
+                return assemblies.FirstOrDefault(a => IsUserAssembly(a));
+            }
+            catch (Exception ex) {
+                log.FormattedError(typeof(AssemblyHelper), ex, "Unable to get entry assembly. Error: {0}", ex.Message);
+            }
+
+            return null;
+        }
+
+        private static bool IsUserAssembly(Assembly assembly) {
+            if (assembly == null)
+                return false;
+
+            if (!String.IsNullOrEmpty(assembly.FullName) && (assembly.FullName.StartsWith("System.") || assembly.FullName.StartsWith("Microsoft.")))
+                return false;
+
+            string company = assembly.GetCompany() ?? String.Empty;
+            string[] nonUserCompanies = new[] { "Exceptionless", "Microsoft" };
+            if (nonUserCompanies.Any(c => company.IndexOf(c, StringComparison.OrdinalIgnoreCase) >= 0))
+                return false;
+
+            if (assembly.FullName == typeof(ExceptionlessClient).GetTypeInfo().Assembly.FullName)
+                return false;
+
+            return true;
+        }
+
+        public static string GetVersionFromAssembly(Assembly assembly) {
+            if (assembly == null)
+                return null;
+
+            string version = assembly.GetInformationalVersion();
+            if (String.IsNullOrEmpty(version) || String.Equals(version, "0.0.0.0"))
+                version = assembly.GetFileVersion();
+
+            if (String.IsNullOrEmpty(version) || String.Equals(version, "0.0.0.0"))
+                version = assembly.GetVersion();
+
+            if (String.IsNullOrEmpty(version) || String.Equals(version, "0.0.0.0")) {
+                var assemblyName = assembly.GetAssemblyName();
+                version = assemblyName != null ? assemblyName.Version.ToString() : null;
+            }
+
+            return !String.IsNullOrEmpty(version) && !String.Equals(version, "0.0.0.0") ? version : null;
+        }
+
         public static string GetAssemblyTitle() {
             // Get all attributes on this assembly
             var assembly = GetRootAssembly();


### PR DESCRIPTION
This removes .NET Platform 1.0 and 1.1 only supported apis from the core netstandard client.

- https://github.com/aspnet/Announcements/issues/237
- https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.platformabstractions.platformservices.default?view=dotnet-plat-ext-1.1
- https://stackoverflow.com/questions/46226283/netstandard-2-0-does-not-have-appdomain-currentdomain-setupinformation-configura
- http://www.hishambinateya.com/goodbye-platform-abstractions
- https://github.com/aspnet/PlatformAbstractions/issues/50

There is a slight change in behavior as I'm trying to reuse some existing logic to smartly detect the entry assembly and exclude Exceptionless and Microsoft Packages (We could use this in a few more spots but wanted to keep this minimal). Here is the diff before using the new GetEntryAssembly helper (which picks a different assembly as our samples start with Exceptionless...)

![image](https://github.com/exceptionless/Exceptionless.Net/assets/1020579/ee51e6bf-4471-4290-99a1-c41885726c46)
