### PR TITLE
Fixes request-info collection across the ASP.NET Core / ASP.NET (System.Web) / WebApi platform integrations to avoid reading POST bodies for handled errors,

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -2,18 +2,19 @@ name: Build Linux
 on: [push, pull_request]
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_NOLOGO: 1
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - name: Setup .NET Core 8
-      uses: actions/setup-dotnet@v4
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.x
+        global-json-file: global.json
     - name: Build Reason
       run: "echo ref: ${{github.ref}} event: ${{github.event_name}}"
     - name: Build Version

--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -2,18 +2,19 @@ name: Build OSX
 on: [push, pull_request]
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_NOLOGO: 1
 jobs:
   build:
     runs-on: macOS-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - name: Setup .NET Core 8
-      uses: actions/setup-dotnet@v4
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.x
+        global-json-file: global.json
     - name: Build Reason
       run: "echo ref: ${{github.ref}} event: ${{github.event_name}}"
     - name: Build Version

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -2,18 +2,19 @@ name: Build Windows
 on: [push, pull_request]
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_NOLOGO: 1
 jobs:
   build:
     runs-on: windows-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - name: Setup .NET Core 8
-      uses: actions/setup-dotnet@v4
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.x
+        global-json-file: global.json
     - name: Build Reason
       run: "echo ref: ${{github.ref}} event: ${{github.event_name}}"
     - name: Build Version

--- a/build/common.props
+++ b/build/common.props
@@ -8,7 +8,7 @@
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
-    <Copyright>Copyright (c) 2025 Exceptionless.  All rights reserved.</Copyright>
+    <Copyright>Copyright © $([System.DateTime]::Now.ToString(yyyy)) Exceptionless.  All rights reserved.</Copyright>
     <Authors>Exceptionless</Authors>
     <NoWarn>$(NoWarn);CS1591;NU1701</NoWarn>
     <WarningsAsErrors>true</WarningsAsErrors>

--- a/build/common.props
+++ b/build/common.props
@@ -6,6 +6,7 @@
     <PackageReleaseNotes>https://github.com/exceptionless/Exceptionless.Net/releases</PackageReleaseNotes>
     <MinVerSkip Condition="'$(Configuration)' == 'Debug'">true</MinVerSkip>
     <MinVerTagPrefix>v</MinVerTagPrefix>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
     <Copyright>Copyright (c) 2025 Exceptionless.  All rights reserved.</Copyright>
     <Authors>Exceptionless</Authors>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100",
     "rollForward": "latestMinor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "10.0.100",
     "rollForward": "latestMinor"
   }
 }

--- a/samples/Exceptionless.SampleAspNetCore/Controllers/ValuesController.cs
+++ b/samples/Exceptionless.SampleAspNetCore/Controllers/ValuesController.cs
@@ -26,14 +26,16 @@ namespace Exceptionless.SampleAspNetCore.Controllers {
 
             try {
                 throw new Exception($"Handled Exception: {Guid.NewGuid()}");
-            } catch (Exception handledException) {
+            }
+            catch (Exception handledException) {
                 // Use the ToExceptionless extension method to submit this handled exception to Exceptionless using the client instance from DI.
                 handledException.ToExceptionless(_exceptionlessClient).Submit();
             }
 
             try {
                 throw new Exception($"Handled Exception (Default Client): {Guid.NewGuid()}");
-            } catch (Exception handledException) {
+            }
+            catch (Exception handledException) {
                 // Use the ToExceptionless extension method to submit this handled exception to Exceptionless using the default client instance (ExceptionlessClient.Default).
                 // This works and is convenient, but its generally not recommended to use static singleton instances because it makes testing and
                 // other things harder.

--- a/src/Platforms/Exceptionless.AspNetCore/ExceptionlessAspNetCorePlugin.cs
+++ b/src/Platforms/Exceptionless.AspNetCore/ExceptionlessAspNetCorePlugin.cs
@@ -32,7 +32,7 @@ namespace Exceptionless.AspNetCore {
                 return;
 
             try {
-                ri = httpContext.GetRequestInfo(context.Client.Configuration);
+                ri = httpContext.GetRequestInfo(context.Client.Configuration, context.ContextData.IsUnhandledError);
             } catch (Exception ex) {
                 context.Log.Error(typeof(ExceptionlessAspNetCorePlugin), ex, "Error adding request info.");
             }

--- a/src/Platforms/Exceptionless.AspNetCore/ExceptionlessExtensions.cs
+++ b/src/Platforms/Exceptionless.AspNetCore/ExceptionlessExtensions.cs
@@ -68,8 +68,9 @@ namespace Exceptionless {
         /// </summary>
         /// <param name="context">The http context to gather information from.</param>
         /// <param name="config">The config.</param>
-        public static RequestInfo GetRequestInfo(this HttpContext context, ExceptionlessConfiguration config) {
-            return RequestInfoCollector.Collect(context, config);
+        /// <param name="isUnhandledError">Whether this is an unhandled error. POST data is only collected for unhandled errors to avoid consuming the request stream.</param>
+        public static RequestInfo GetRequestInfo(this HttpContext context, ExceptionlessConfiguration config, bool isUnhandledError = false) {
+            return RequestInfoCollector.Collect(context, config, isUnhandledError);
         }
 
         /// <summary>

--- a/src/Platforms/Exceptionless.AspNetCore/RequestInfoCollector.cs
+++ b/src/Platforms/Exceptionless.AspNetCore/RequestInfoCollector.cs
@@ -16,7 +16,7 @@ namespace Exceptionless.AspNetCore {
         private const int MAX_BODY_SIZE = 50 * 1024;
         private const int MAX_DATA_ITEM_LENGTH = 1000;
 
-        public static RequestInfo Collect(HttpContext context, ExceptionlessConfiguration config) {
+        public static RequestInfo Collect(HttpContext context, ExceptionlessConfiguration config, bool isUnhandledError = false) {
             if (context == null)
                 return null;
 
@@ -50,7 +50,9 @@ namespace Exceptionless.AspNetCore {
             if (config.IncludeQueryString)
                 info.QueryString = context.Request.Query.ToDictionary(exclusionList);
 
-            if (config.IncludePostData && !String.Equals(context.Request.Method, "GET", StringComparison.OrdinalIgnoreCase))
+            // Only collect POST data for unhandled errors to avoid consuming the request stream
+            // and breaking model binding for handled errors where the app continues processing.
+            if (config.IncludePostData && isUnhandledError && !String.Equals(context.Request.Method, "GET", StringComparison.OrdinalIgnoreCase))
                 info.PostData = GetPostData(context, config, exclusionList);
 
             return info;
@@ -59,12 +61,7 @@ namespace Exceptionless.AspNetCore {
         private static object GetPostData(HttpContext context, ExceptionlessConfiguration config, string[] exclusionList) {
             var log = config.Resolver.GetLog();
 
-            if (context.Request.HasFormContentType && context.Request.Form.Count > 0) {
-                log.Debug("Reading POST data from Request.Form");
-                return context.Request.Form.ToDictionary(exclusionList);
-            }
-
-            var contentLength = context.Request.ContentLength.GetValueOrDefault();
+            long contentLength = context.Request.ContentLength.GetValueOrDefault();
             if(contentLength == 0) {
                 string message = "Content-length was zero, empty post.";
                 log.Debug(message);
@@ -96,6 +93,11 @@ namespace Exceptionless.AspNetCore {
                     string message = "Unable to get POST data: The stream position was not at 0.";
                     log.Debug(message);
                     return message;
+                }
+
+                if (context.Request.HasFormContentType && context.Request.Form.Count > 0) {
+                    log.Debug("Reading POST data from Request.Form");
+                    return context.Request.Form.ToDictionary(exclusionList);
                 }
 
                 // pass default values, except for leaveOpen: true. This prevents us from disposing the underlying stream

--- a/src/Platforms/Exceptionless.AspNetCore/RequestInfoCollector.cs
+++ b/src/Platforms/Exceptionless.AspNetCore/RequestInfoCollector.cs
@@ -62,7 +62,7 @@ namespace Exceptionless.AspNetCore {
             var log = config.Resolver.GetLog();
 
             long contentLength = context.Request.ContentLength.GetValueOrDefault();
-            if(contentLength == 0) {
+            if (contentLength == 0) {
                 string message = "Content-length was zero, empty post.";
                 log.Debug(message);
                 return message;
@@ -95,8 +95,11 @@ namespace Exceptionless.AspNetCore {
                     return message;
                 }
 
+                // Form check must come after seekability and position checks above: accessing
+                // Request.Form triggers reading the request body stream.
                 if (context.Request.HasFormContentType && context.Request.Form.Count > 0) {
                     log.Debug("Reading POST data from Request.Form");
+                    context.Request.Body.Position = originalPosition;
                     return context.Request.Form.ToDictionary(exclusionList);
                 }
 

--- a/src/Platforms/Exceptionless.Web/ExceptionlessWebExtensions.cs
+++ b/src/Platforms/Exceptionless.Web/ExceptionlessWebExtensions.cs
@@ -11,11 +11,12 @@ namespace Exceptionless {
         /// </summary>
         /// <param name="context">The http context to gather information from.</param>
         /// <param name="config">The config.</param>
-        public static RequestInfo GetRequestInfo(this HttpContext context, ExceptionlessConfiguration config) {
+        /// <param name="isUnhandledError">Whether this is an unhandled error. POST data is only collected for unhandled errors to avoid consuming the request stream.</param>
+        public static RequestInfo GetRequestInfo(this HttpContext context, ExceptionlessConfiguration config, bool isUnhandledError = false) {
             if (context == null)
                 return null;
 
-            return GetRequestInfo(context.ToWrapped(), config);
+            return GetRequestInfo(context.ToWrapped(), config, isUnhandledError);
         }
 
         /// <summary>
@@ -23,11 +24,12 @@ namespace Exceptionless {
         /// </summary>
         /// <param name="context">The http context to gather information from.</param>
         /// <param name="config">The config.</param>
-        public static RequestInfo GetRequestInfo(this HttpContextBase context, ExceptionlessConfiguration config) {
+        /// <param name="isUnhandledError">Whether this is an unhandled error. POST data is only collected for unhandled errors to avoid consuming the request stream.</param>
+        public static RequestInfo GetRequestInfo(this HttpContextBase context, ExceptionlessConfiguration config, bool isUnhandledError = false) {
             if (context == null && HttpContext.Current != null)
                 context = HttpContext.Current.ToWrapped();
 
-            return RequestInfoCollector.Collect(context, config);
+            return RequestInfoCollector.Collect(context, config, isUnhandledError);
         }
 
         /// <summary>

--- a/src/Platforms/Exceptionless.Web/ExceptionlessWebPlugin.cs
+++ b/src/Platforms/Exceptionless.Web/ExceptionlessWebPlugin.cs
@@ -35,7 +35,7 @@ namespace Exceptionless.Web {
                 return;
 
             try {
-                ri = httpContext.GetRequestInfo(context.Client.Configuration);
+                ri = httpContext.GetRequestInfo(context.Client.Configuration, context.ContextData.IsUnhandledError);
             } catch (Exception ex) {
                 context.Log.Error(typeof(ExceptionlessWebPlugin), ex, "Error adding request info.");
             }

--- a/src/Platforms/Exceptionless.Web/RequestInfoCollector.cs
+++ b/src/Platforms/Exceptionless.Web/RequestInfoCollector.cs
@@ -15,7 +15,7 @@ namespace Exceptionless.ExtendedData {
         private const int MAX_BODY_SIZE = 50 * 1024;
         private const int MAX_DATA_ITEM_LENGTH = 1000;
 
-        public static RequestInfo Collect(HttpContextBase context, ExceptionlessConfiguration config) {
+        public static RequestInfo Collect(HttpContextBase context, ExceptionlessConfiguration config, bool isUnhandledError = false) {
             if (context == null)
                 return null;
 
@@ -63,7 +63,9 @@ namespace Exceptionless.ExtendedData {
                 }
             }
 
-            if (config.IncludePostData && !String.Equals(context.Request.HttpMethod, "GET", StringComparison.OrdinalIgnoreCase))
+            // Only collect POST data for unhandled errors to avoid consuming the request stream
+            // and breaking model binding for handled errors where the app continues processing.
+            if (config.IncludePostData && isUnhandledError && !String.Equals(context.Request.HttpMethod, "GET", StringComparison.OrdinalIgnoreCase))
                 info.PostData = GetPostData(context, config, exclusionList);
 
             return info;
@@ -72,13 +74,7 @@ namespace Exceptionless.ExtendedData {
         private static object GetPostData(HttpContextBase context, ExceptionlessConfiguration config, string[] exclusionList) {
             var log = config.Resolver.GetLog();
 
-            if (context.Request.Form.Count > 0) {
-                log.Debug("Reading POST data from Request.Form");
-
-                return context.Request.Form.ToDictionary(exclusionList);
-            }
-
-            var contentLength = context.Request.ContentLength;
+            int contentLength = context.Request.ContentLength;
             if (contentLength == 0) {
                 string message = "Content-length was zero, empty post.";
                 log.Debug(message);
@@ -112,7 +108,13 @@ namespace Exceptionless.ExtendedData {
                     return message;
                 }
 
-                var maxDataToRead = contentLength == 0 ? MAX_BODY_SIZE : contentLength;
+                if (context.Request.Form.Count > 0) {
+                    log.Debug("Reading POST data from Request.Form");
+
+                    return context.Request.Form.ToDictionary(exclusionList);
+                }
+
+                int maxDataToRead = contentLength == 0 ? MAX_BODY_SIZE : contentLength;
 
                 // pass default values, except for leaveOpen: true. This prevents us from disposing the underlying stream
                 using (var inputStream = new StreamReader(context.Request.InputStream, Encoding.UTF8, true, 1024, true)) {

--- a/src/Platforms/Exceptionless.Web/RequestInfoCollector.cs
+++ b/src/Platforms/Exceptionless.Web/RequestInfoCollector.cs
@@ -108,9 +108,11 @@ namespace Exceptionless.ExtendedData {
                     return message;
                 }
 
+                // Form check must come after seekability and position checks above: accessing
+                // Request.Form triggers reading the request body stream.
                 if (context.Request.Form.Count > 0) {
                     log.Debug("Reading POST data from Request.Form");
-
+                    context.Request.InputStream.Position = originalPosition;
                     return context.Request.Form.ToDictionary(exclusionList);
                 }
 

--- a/src/Platforms/Exceptionless.WebApi/ExceptionlessWebApiExtensions.cs
+++ b/src/Platforms/Exceptionless.WebApi/ExceptionlessWebApiExtensions.cs
@@ -65,8 +65,9 @@ namespace Exceptionless {
         /// </summary>
         /// <param name="context">The http action context to gather information from.</param>
         /// <param name="config">The config.</param>
-        public static RequestInfo GetRequestInfo(this HttpActionContext context, ExceptionlessConfiguration config) {
-            return RequestInfoCollector.Collect(context, config);
+        /// <param name="isUnhandledError">Whether this is an unhandled error. POST data collection is not implemented for WebApi.</param>
+        public static RequestInfo GetRequestInfo(this HttpActionContext context, ExceptionlessConfiguration config, bool isUnhandledError = false) {
+            return RequestInfoCollector.Collect(context, config, isUnhandledError);
         }
 
         /// <summary>

--- a/src/Platforms/Exceptionless.WebApi/ExceptionlessWebApiPlugin.cs
+++ b/src/Platforms/Exceptionless.WebApi/ExceptionlessWebApiPlugin.cs
@@ -29,7 +29,7 @@ namespace Exceptionless.WebApi {
                 return;
 
             try {
-                ri = actionContext.GetRequestInfo(context.Client.Configuration);
+                ri = actionContext.GetRequestInfo(context.Client.Configuration, context.ContextData.IsUnhandledError);
             } catch (Exception ex) {
                 context.Log.Error(typeof(ExceptionlessWebApiPlugin), ex, "Error adding request info.");
             }

--- a/src/Platforms/Exceptionless.WebApi/RequestInfoCollector.cs
+++ b/src/Platforms/Exceptionless.WebApi/RequestInfoCollector.cs
@@ -51,7 +51,7 @@ namespace Exceptionless.ExtendedData {
             // POST data collection is not implemented for WebApi due to async complexities and
             // the difficulty of reading the request body without interfering with model binding.
             // Other platforms (AspNetCore, Web) now only collect POST data for unhandled errors.
-            // TODO: support getting post data asyncly.
+            // TODO: support getting post data asynchronously.
             //if (config.IncludePostData && isUnhandledError && context.Request.Method != HttpMethod.Get)
             //    info.PostData = GetPostData(context, config, exclusionList);
 

--- a/src/Platforms/Exceptionless.WebApi/RequestInfoCollector.cs
+++ b/src/Platforms/Exceptionless.WebApi/RequestInfoCollector.cs
@@ -14,7 +14,7 @@ namespace Exceptionless.ExtendedData {
     internal static class RequestInfoCollector {
         private const int MAX_DATA_ITEM_LENGTH = 1000;
 
-        public static RequestInfo Collect(HttpActionContext context, ExceptionlessConfiguration config) {
+        public static RequestInfo Collect(HttpActionContext context, ExceptionlessConfiguration config, bool isUnhandledError = false) {
             if (context == null)
                 return null;
 
@@ -48,8 +48,11 @@ namespace Exceptionless.ExtendedData {
             if (config.IncludeQueryString)
                 info.QueryString = context.Request.RequestUri.ParseQueryString().ToDictionary(exclusionList);
 
+            // POST data collection is not implemented for WebApi due to async complexities and
+            // the difficulty of reading the request body without interfering with model binding.
+            // Other platforms (AspNetCore, Web) now only collect POST data for unhandled errors.
             // TODO: support getting post data asyncly.
-            //if (config.IncludePostData && context.Request.Method != HttpMethod.Get)
+            //if (config.IncludePostData && isUnhandledError && context.Request.Method != HttpMethod.Get)
             //    info.PostData = GetPostData(context, config, exclusionList);
 
             return info;

--- a/test/Exceptionless.Tests/Exceptionless.Tests.csproj
+++ b/test/Exceptionless.Tests/Exceptionless.Tests.csproj
@@ -29,10 +29,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Exceptionless\Exceptionless.csproj" />
+    <ProjectReference Include="..\..\src\Platforms\Exceptionless.AspNetCore\Exceptionless.AspNetCore.csproj" />
     <ProjectReference Include="..\Exceptionless.TestHarness\Exceptionless.TestHarness.csproj" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
     <PackageReference Include="Moq" Version="4.20.72" />

--- a/test/Exceptionless.Tests/Exceptionless.Tests.csproj
+++ b/test/Exceptionless.Tests/Exceptionless.Tests.csproj
@@ -2,10 +2,10 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-<TargetFramework>net8.0</TargetFramework>
+<TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-<TargetFrameworks>net8.0;net462</TargetFrameworks>
+<TargetFrameworks>net10.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,7 +19,7 @@
     <None Include="app.config" />
   </ItemGroup>
 
-<PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0' " Label="Build">
+<PropertyGroup Condition=" '$(TargetFramework)' == 'net10.0' " Label="Build">
     <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 

--- a/test/Exceptionless.Tests/Platforms/AspNetCoreRequestInfoTests.cs
+++ b/test/Exceptionless.Tests/Platforms/AspNetCoreRequestInfoTests.cs
@@ -68,9 +68,13 @@ namespace Exceptionless.Tests.Platforms {
         }
 
         private static DefaultHttpContext CreateFormHttpContext() {
+            const string formBody = "name=world";
+            var bodyBytes = Encoding.UTF8.GetBytes(formBody);
             var context = new DefaultHttpContext();
             context.Request.Method = HttpMethods.Post;
             context.Request.ContentType = "application/x-www-form-urlencoded";
+            context.Request.ContentLength = bodyBytes.Length;
+            context.Request.Body = new MemoryStream(bodyBytes);
             context.Request.Form = new FormCollection(new Dictionary<string, StringValues> {
                 ["name"] = "world"
             });

--- a/test/Exceptionless.Tests/Platforms/AspNetCoreRequestInfoTests.cs
+++ b/test/Exceptionless.Tests/Platforms/AspNetCoreRequestInfoTests.cs
@@ -1,0 +1,47 @@
+using System.IO;
+using System.Text;
+using Exceptionless;
+using Exceptionless.Dependency;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Exceptionless.Tests.Platforms {
+    public class AspNetCoreRequestInfoTests {
+        [Fact]
+        public void GetRequestInfo_DoesNotReadPostData_ForHandledErrors() {
+            var context = CreateHttpContext("hello=world");
+            var config = new ExceptionlessConfiguration(DependencyResolver.CreateDefault());
+
+            var requestInfo = context.GetRequestInfo(config);
+
+            Assert.NotNull(requestInfo);
+            Assert.Null(requestInfo.PostData);
+            Assert.Equal(0L, context.Request.Body.Position);
+        }
+
+        [Fact]
+        public void GetRequestInfo_ReadsAndRestoresPostData_ForUnhandledErrors() {
+            const string body = "{\"hello\":\"world\"}";
+            var context = CreateHttpContext(body);
+            var config = new ExceptionlessConfiguration(DependencyResolver.CreateDefault());
+
+            context.Request.Body.Position = 5;
+
+            var requestInfo = context.GetRequestInfo(config, isUnhandledError: true);
+
+            Assert.NotNull(requestInfo);
+            Assert.Equal(body, Assert.IsType<string>(requestInfo.PostData));
+            Assert.Equal(5L, context.Request.Body.Position);
+        }
+
+        private static DefaultHttpContext CreateHttpContext(string body) {
+            var bodyBytes = Encoding.UTF8.GetBytes(body);
+            var context = new DefaultHttpContext();
+            context.Request.Method = HttpMethods.Post;
+            context.Request.ContentType = "application/json";
+            context.Request.Body = new MemoryStream(bodyBytes);
+            context.Request.ContentLength = bodyBytes.Length;
+            return context;
+        }
+    }
+}

--- a/test/Exceptionless.Tests/Platforms/AspNetCoreRequestInfoTests.cs
+++ b/test/Exceptionless.Tests/Platforms/AspNetCoreRequestInfoTests.cs
@@ -1,19 +1,24 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using Exceptionless;
 using Exceptionless.Dependency;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
 using Xunit;
 
 namespace Exceptionless.Tests.Platforms {
     public class AspNetCoreRequestInfoTests {
         [Fact]
         public void GetRequestInfo_DoesNotReadPostData_ForHandledErrors() {
+            // Arrange
             var context = CreateHttpContext("hello=world");
             var config = new ExceptionlessConfiguration(DependencyResolver.CreateDefault());
 
+            // Act
             var requestInfo = context.GetRequestInfo(config);
 
+            // Assert
             Assert.NotNull(requestInfo);
             Assert.Null(requestInfo.PostData);
             Assert.Equal(0L, context.Request.Body.Position);
@@ -21,17 +26,35 @@ namespace Exceptionless.Tests.Platforms {
 
         [Fact]
         public void GetRequestInfo_ReadsAndRestoresPostData_ForUnhandledErrors() {
+            // Arrange
             const string body = "{\"hello\":\"world\"}";
             var context = CreateHttpContext(body);
             var config = new ExceptionlessConfiguration(DependencyResolver.CreateDefault());
 
             context.Request.Body.Position = 5;
 
+            // Act
             var requestInfo = context.GetRequestInfo(config, isUnhandledError: true);
 
+            // Assert
             Assert.NotNull(requestInfo);
             Assert.Equal(body, Assert.IsType<string>(requestInfo.PostData));
             Assert.Equal(5L, context.Request.Body.Position);
+        }
+
+        [Fact]
+        public void GetRequestInfo_ReadsFormData_ForUnhandledErrors() {
+            // Arrange
+            var context = CreateFormHttpContext();
+            var config = new ExceptionlessConfiguration(DependencyResolver.CreateDefault());
+
+            // Act
+            var requestInfo = context.GetRequestInfo(config, isUnhandledError: true);
+
+            // Assert
+            Assert.NotNull(requestInfo);
+            var postData = Assert.IsType<Dictionary<string, string>>(requestInfo.PostData);
+            Assert.Equal("world", postData["name"]);
         }
 
         private static DefaultHttpContext CreateHttpContext(string body) {
@@ -41,6 +64,16 @@ namespace Exceptionless.Tests.Platforms {
             context.Request.ContentType = "application/json";
             context.Request.Body = new MemoryStream(bodyBytes);
             context.Request.ContentLength = bodyBytes.Length;
+            return context;
+        }
+
+        private static DefaultHttpContext CreateFormHttpContext() {
+            var context = new DefaultHttpContext();
+            context.Request.Method = HttpMethods.Post;
+            context.Request.ContentType = "application/x-www-form-urlencoded";
+            context.Request.Form = new FormCollection(new Dictionary<string, StringValues> {
+                ["name"] = "world"
+            });
             return context;
         }
     }


### PR DESCRIPTION
This PR updates request-info collection across the ASP.NET Core / ASP.NET (System.Web) / WebApi platform integrations to avoid reading POST bodies for handled errors, and modernizes build configuration to use the SDK from global.json.

Changes:

1. Gate POST body/form collection behind an isUnhandledError flag in Web + ASP.NET Core request collectors and propagate that flag from platform plugins.
2. Add ASP.NET Core request-info unit tests and add the ASP.NET Core platform dependency to the test project.
3. Update build tooling: bump global.json SDK, tweak common props, and refresh GitHub Actions workflow steps.