### PR TITLE
Add .NET MAUI sample app

### DIFF
--- a/Exceptionless.Net.slnx
+++ b/Exceptionless.Net.slnx
@@ -19,6 +19,7 @@
     <Project Path="samples/Exceptionless.SampleHosting/Exceptionless.SampleHosting.csproj" />
     <Project Path="samples/Exceptionless.SampleLambda/Exceptionless.SampleLambda.csproj" />
     <Project Path="samples/Exceptionless.SampleLambdaAspNetCore/Exceptionless.SampleLambdaAspNetCore.csproj" />
+    <Project Path="samples/Exceptionless.SampleMaui/Exceptionless.SampleMaui.csproj" />
     <Project Path="samples/Exceptionless.SampleMvc/Exceptionless.SampleMvc.csproj">
       <BuildDependency Project="src/Exceptionless/Exceptionless.csproj" />
       <BuildDependency Project="src/Platforms/Exceptionless.Mvc/Exceptionless.Mvc.csproj" />

--- a/samples/Exceptionless.SampleMaui/App.cs
+++ b/samples/Exceptionless.SampleMaui/App.cs
@@ -1,0 +1,20 @@
+namespace Exceptionless.SampleMaui;
+
+public sealed class App : Application {
+    private readonly ExceptionlessClient _exceptionlessClient;
+    private readonly MainPage _mainPage;
+
+    public App(MainPage mainPage, ExceptionlessClient exceptionlessClient) {
+        _exceptionlessClient = exceptionlessClient;
+        _mainPage = mainPage;
+    }
+
+    protected override Window CreateWindow(IActivationState? activationState) {
+        return new Window(_mainPage);
+    }
+
+    protected override void OnSleep() {
+        _ = _exceptionlessClient.ProcessQueueAsync();
+        base.OnSleep();
+    }
+}

--- a/samples/Exceptionless.SampleMaui/App.cs
+++ b/samples/Exceptionless.SampleMaui/App.cs
@@ -2,15 +2,20 @@ namespace Exceptionless.SampleMaui;
 
 public sealed class App : Application {
     private readonly ExceptionlessClient _exceptionlessClient;
+    private readonly SampleDogfoodRunner _dogfoodRunner;
     private readonly MainPage _mainPage;
 
-    public App(MainPage mainPage, ExceptionlessClient exceptionlessClient) {
+    public App(MainPage mainPage, ExceptionlessClient exceptionlessClient, SampleDogfoodRunner dogfoodRunner) {
         _exceptionlessClient = exceptionlessClient;
+        _dogfoodRunner = dogfoodRunner;
         _mainPage = mainPage;
     }
 
     protected override Window CreateWindow(IActivationState? activationState) {
-        return new Window(_mainPage);
+        var window = new Window(_mainPage);
+        _ = _dogfoodRunner.RunIfRequestedAsync();
+
+        return window;
     }
 
     protected override void OnSleep() {

--- a/samples/Exceptionless.SampleMaui/Exceptionless.SampleMaui.csproj
+++ b/samples/Exceptionless.SampleMaui/Exceptionless.SampleMaui.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Exceptionless.SampleMaui</RootNamespace>
+    <UseMaui>true</UseMaui>
+    <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <ApplicationTitle>Exceptionless MAUI Sample</ApplicationTitle>
+    <ApplicationId>com.exceptionless.samplemaui</ApplicationId>
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+    <ApplicationVersion>1</ApplicationVersion>
+    <WindowsPackageType>None</WindowsPackageType>
+
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
+    <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#3A6EA5" />
+    <MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#3A6EA5" BaseSize="128,128" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Exceptionless\Exceptionless.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Exceptionless.SampleMaui/MainPage.cs
+++ b/samples/Exceptionless.SampleMaui/MainPage.cs
@@ -1,0 +1,193 @@
+using Exceptionless.Logging;
+using Microsoft.Maui.Controls.Shapes;
+
+namespace Exceptionless.SampleMaui;
+
+public sealed class MainPage : ContentPage {
+    private readonly ExceptionlessClient _exceptionlessClient;
+    private readonly Label _statusLabel;
+    private readonly Label _lastReferenceIdLabel;
+    private readonly ActivityIndicator _activityIndicator;
+
+    public MainPage(ExceptionlessClient exceptionlessClient) {
+        _exceptionlessClient = exceptionlessClient;
+
+        Title = "Exceptionless";
+        BackgroundColor = Color.FromArgb("#F6F8FA");
+
+        _statusLabel = new Label {
+            Text = "Ready",
+            FontSize = 14,
+            TextColor = Color.FromArgb("#314256"),
+            LineBreakMode = LineBreakMode.WordWrap
+        };
+
+        _lastReferenceIdLabel = new Label {
+            Text = "Last reference id: none",
+            FontSize = 13,
+            TextColor = Color.FromArgb("#576575"),
+            LineBreakMode = LineBreakMode.TailTruncation
+        };
+
+        _activityIndicator = new ActivityIndicator {
+            IsVisible = false,
+            Color = Color.FromArgb("#276749")
+        };
+
+        Content = BuildContent();
+    }
+
+    private View BuildContent() {
+        var sendExceptionButton = CreateActionButton("Send Handled Exception", OnSendExceptionClicked);
+        var sendLogButton = CreateActionButton("Send Warning Log", OnSendLogClicked);
+        var trackFeatureButton = CreateActionButton("Track Feature", OnTrackFeatureClicked);
+        var flushButton = CreateActionButton("Flush Queue", OnFlushClicked);
+
+        return new ScrollView {
+            Content = new VerticalStackLayout {
+                Padding = new Thickness(24, 28),
+                Spacing = 18,
+                Children = {
+                    new Label {
+                        Text = "Exceptionless MAUI Sample",
+                        FontSize = 26,
+                        FontAttributes = FontAttributes.Bold,
+                        TextColor = Color.FromArgb("#1D2733")
+                    },
+                    new Label {
+                        Text = "Submit sample events through the core Exceptionless client.",
+                        FontSize = 15,
+                        TextColor = Color.FromArgb("#576575"),
+                        LineBreakMode = LineBreakMode.WordWrap
+                    },
+                    new Border {
+                        Stroke = Color.FromArgb("#D8DEE6"),
+                        StrokeThickness = 1,
+                        BackgroundColor = Colors.White,
+                        StrokeShape = new RoundRectangle { CornerRadius = 8 },
+                        Padding = new Thickness(18),
+                        Content = new VerticalStackLayout {
+                            Spacing = 12,
+                            Children = {
+                                new Label {
+                                    Text = "Client",
+                                    FontSize = 18,
+                                    FontAttributes = FontAttributes.Bold,
+                                    TextColor = Color.FromArgb("#1D2733")
+                                },
+                                new Label {
+                                    Text = $"Server: {_exceptionlessClient.Configuration.ServerUrl}",
+                                    FontSize = 13,
+                                    TextColor = Color.FromArgb("#576575"),
+                                    LineBreakMode = LineBreakMode.TailTruncation
+                                },
+                                new Label {
+                                    Text = $"Private information: {_exceptionlessClient.Configuration.IncludePrivateInformation}",
+                                    FontSize = 13,
+                                    TextColor = Color.FromArgb("#576575")
+                                },
+                                _statusLabel,
+                                _lastReferenceIdLabel,
+                                _activityIndicator
+                            }
+                        }
+                    },
+                    new Grid {
+                        ColumnDefinitions = {
+                            new ColumnDefinition { Width = GridLength.Star },
+                            new ColumnDefinition { Width = GridLength.Star }
+                        },
+                        RowDefinitions = {
+                            new RowDefinition { Height = GridLength.Auto },
+                            new RowDefinition { Height = GridLength.Auto }
+                        },
+                        ColumnSpacing = 12,
+                        RowSpacing = 12,
+                        Children = {
+                            sendExceptionButton,
+                            sendLogButton,
+                            trackFeatureButton,
+                            flushButton
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    private static Button CreateActionButton(string text, EventHandler clicked) {
+        var button = new Button {
+            Text = text,
+            BackgroundColor = Color.FromArgb("#285A84"),
+            TextColor = Colors.White,
+            CornerRadius = 8,
+            FontAttributes = FontAttributes.Bold,
+            MinimumHeightRequest = 48
+        };
+
+        button.Clicked += clicked;
+        return button;
+    }
+
+    private async void OnSendExceptionClicked(object? sender, EventArgs e) {
+        await RunClientActionAsync("Handled exception queued.", () => {
+            string referenceId = Guid.NewGuid().ToString("N");
+
+            try {
+                throw new InvalidOperationException("Exceptionless MAUI sample handled exception.");
+            } catch (Exception ex) {
+                ex.ToExceptionless(_exceptionlessClient)
+                    .SetReferenceId(referenceId)
+                    .AddTags("handled")
+                    .SetProperty("Screen", nameof(MainPage))
+                    .Submit();
+            }
+
+            SetLastReferenceId(referenceId);
+            return Task.CompletedTask;
+        });
+    }
+
+    private async void OnSendLogClicked(object? sender, EventArgs e) {
+        await RunClientActionAsync("Warning log queued.", () => {
+            _exceptionlessClient.SubmitLog("Exceptionless.SampleMaui.MainPage", "MAUI sample warning log.", LogLevel.Warn);
+            SetLastReferenceId(_exceptionlessClient.GetLastReferenceId());
+            return Task.CompletedTask;
+        });
+    }
+
+    private async void OnTrackFeatureClicked(object? sender, EventArgs e) {
+        await RunClientActionAsync("Feature usage queued.", () => {
+            _exceptionlessClient.SubmitFeatureUsage("MauiSample.TrackFeature");
+            SetLastReferenceId(_exceptionlessClient.GetLastReferenceId());
+            return Task.CompletedTask;
+        });
+    }
+
+    private async void OnFlushClicked(object? sender, EventArgs e) {
+        await RunClientActionAsync("Queue processed.", () => _exceptionlessClient.ProcessQueueAsync());
+    }
+
+    private async Task RunClientActionAsync(string successMessage, Func<Task> action) {
+        try {
+            _activityIndicator.IsVisible = true;
+            _activityIndicator.IsRunning = true;
+            _statusLabel.Text = "Working...";
+
+            await action();
+
+            _statusLabel.Text = successMessage;
+        } catch (Exception ex) {
+            _statusLabel.Text = $"Error: {ex.Message}";
+        } finally {
+            _activityIndicator.IsRunning = false;
+            _activityIndicator.IsVisible = false;
+        }
+    }
+
+    private void SetLastReferenceId(string? referenceId) {
+        _lastReferenceIdLabel.Text = String.IsNullOrEmpty(referenceId)
+            ? "Last reference id: none"
+            : $"Last reference id: {referenceId}";
+    }
+}

--- a/samples/Exceptionless.SampleMaui/MainPage.cs
+++ b/samples/Exceptionless.SampleMaui/MainPage.cs
@@ -1,16 +1,18 @@
-using Exceptionless.Logging;
 using Microsoft.Maui.Controls.Shapes;
 
 namespace Exceptionless.SampleMaui;
 
 public sealed class MainPage : ContentPage {
     private readonly ExceptionlessClient _exceptionlessClient;
+    private readonly SampleEventService _sampleEvents;
     private readonly Label _statusLabel;
     private readonly Label _lastReferenceIdLabel;
+    private readonly Label _configLabel;
     private readonly ActivityIndicator _activityIndicator;
 
-    public MainPage(ExceptionlessClient exceptionlessClient) {
+    public MainPage(ExceptionlessClient exceptionlessClient, SampleEventService sampleEvents) {
         _exceptionlessClient = exceptionlessClient;
+        _sampleEvents = sampleEvents;
 
         Title = "Exceptionless";
         BackgroundColor = Color.FromArgb("#F6F8FA");
@@ -29,6 +31,13 @@ public sealed class MainPage : ContentPage {
             LineBreakMode = LineBreakMode.TailTruncation
         };
 
+        _configLabel = new Label {
+            Text = $"Config {SampleEventService.SampleConfigSettingKey}: not loaded",
+            FontSize = 13,
+            TextColor = Color.FromArgb("#576575"),
+            LineBreakMode = LineBreakMode.TailTruncation
+        };
+
         _activityIndicator = new ActivityIndicator {
             IsVisible = false,
             Color = Color.FromArgb("#276749")
@@ -38,6 +47,7 @@ public sealed class MainPage : ContentPage {
     }
 
     private View BuildContent() {
+        var refreshConfigButton = CreateActionButton("Refresh Config", OnRefreshConfigClicked);
         var sendExceptionButton = CreateActionButton("Send Handled Exception", OnSendExceptionClicked);
         var sendLogButton = CreateActionButton("Send Warning Log", OnSendLogClicked);
         var trackFeatureButton = CreateActionButton("Track Feature", OnTrackFeatureClicked);
@@ -88,22 +98,15 @@ public sealed class MainPage : ContentPage {
                                 },
                                 _statusLabel,
                                 _lastReferenceIdLabel,
+                                _configLabel,
                                 _activityIndicator
                             }
                         }
                     },
-                    new Grid {
-                        ColumnDefinitions = {
-                            new ColumnDefinition { Width = GridLength.Star },
-                            new ColumnDefinition { Width = GridLength.Star }
-                        },
-                        RowDefinitions = {
-                            new RowDefinition { Height = GridLength.Auto },
-                            new RowDefinition { Height = GridLength.Auto }
-                        },
-                        ColumnSpacing = 12,
-                        RowSpacing = 12,
+                    new VerticalStackLayout {
+                        Spacing = 12,
                         Children = {
+                            refreshConfigButton,
                             sendExceptionButton,
                             sendLogButton,
                             trackFeatureButton,
@@ -129,20 +132,16 @@ public sealed class MainPage : ContentPage {
         return button;
     }
 
+    private async void OnRefreshConfigClicked(object? sender, EventArgs e) {
+        await RunClientActionAsync("Configuration refreshed.", async () => {
+            await _sampleEvents.RefreshProjectConfigurationAsync();
+            SetConfigValue(_sampleEvents.GetSampleConfigValue());
+        });
+    }
+
     private async void OnSendExceptionClicked(object? sender, EventArgs e) {
         await RunClientActionAsync("Handled exception queued.", () => {
-            string referenceId = Guid.NewGuid().ToString("N");
-
-            try {
-                throw new InvalidOperationException("Exceptionless MAUI sample handled exception.");
-            } catch (Exception ex) {
-                ex.ToExceptionless(_exceptionlessClient)
-                    .SetReferenceId(referenceId)
-                    .AddTags("handled")
-                    .SetProperty("Screen", nameof(MainPage))
-                    .Submit();
-            }
-
+            string referenceId = _sampleEvents.SubmitHandledException();
             SetLastReferenceId(referenceId);
             return Task.CompletedTask;
         });
@@ -150,22 +149,20 @@ public sealed class MainPage : ContentPage {
 
     private async void OnSendLogClicked(object? sender, EventArgs e) {
         await RunClientActionAsync("Warning log queued.", () => {
-            _exceptionlessClient.SubmitLog("Exceptionless.SampleMaui.MainPage", "MAUI sample warning log.", LogLevel.Warn);
-            SetLastReferenceId(_exceptionlessClient.GetLastReferenceId());
+            SetLastReferenceId(_sampleEvents.SubmitWarningLog());
             return Task.CompletedTask;
         });
     }
 
     private async void OnTrackFeatureClicked(object? sender, EventArgs e) {
         await RunClientActionAsync("Feature usage queued.", () => {
-            _exceptionlessClient.SubmitFeatureUsage("MauiSample.TrackFeature");
-            SetLastReferenceId(_exceptionlessClient.GetLastReferenceId());
+            SetLastReferenceId(_sampleEvents.TrackFeatureUsage());
             return Task.CompletedTask;
         });
     }
 
     private async void OnFlushClicked(object? sender, EventArgs e) {
-        await RunClientActionAsync("Queue processed.", () => _exceptionlessClient.ProcessQueueAsync());
+        await RunClientActionAsync("Queue processed.", () => _sampleEvents.FlushQueueAsync());
     }
 
     private async Task RunClientActionAsync(string successMessage, Func<Task> action) {
@@ -177,7 +174,9 @@ public sealed class MainPage : ContentPage {
             await action();
 
             _statusLabel.Text = successMessage;
-        } catch (Exception ex) {
+        } catch (InvalidOperationException ex) {
+            _statusLabel.Text = $"Error: {ex.Message}";
+        } catch (TaskCanceledException ex) {
             _statusLabel.Text = $"Error: {ex.Message}";
         } finally {
             _activityIndicator.IsRunning = false;
@@ -189,5 +188,9 @@ public sealed class MainPage : ContentPage {
         _lastReferenceIdLabel.Text = String.IsNullOrEmpty(referenceId)
             ? "Last reference id: none"
             : $"Last reference id: {referenceId}";
+    }
+
+    private void SetConfigValue(string value) {
+        _configLabel.Text = $"Config {SampleEventService.SampleConfigSettingKey}: {value}";
     }
 }

--- a/samples/Exceptionless.SampleMaui/MauiProgram.cs
+++ b/samples/Exceptionless.SampleMaui/MauiProgram.cs
@@ -1,0 +1,43 @@
+using Exceptionless.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Storage;
+
+namespace Exceptionless.SampleMaui;
+
+public static class MauiProgram {
+    private const string DefaultApiKey = "LhhP1C9gijpSKCslHHCvwdSIz298twx271nTest";
+    private const string DefaultServerUrl = "https://ex.dev.localhost:7111";
+
+    public static MauiApp CreateMauiApp() {
+        var builder = MauiApp.CreateBuilder();
+        var exceptionlessClient = CreateExceptionlessClient();
+
+        builder
+            .UseMauiApp<App>();
+
+        builder.Services.AddSingleton(exceptionlessClient);
+        builder.Services.AddSingleton<MainPage>();
+
+        return builder.Build();
+    }
+
+    private static ExceptionlessClient CreateExceptionlessClient() {
+        string appDataDirectory = FileSystem.Current.AppDataDirectory;
+
+        var client = new ExceptionlessClient(config => {
+            config.ApiKey = Environment.GetEnvironmentVariable("EXCEPTIONLESS_API_KEY") ?? DefaultApiKey;
+            config.ServerUrl = Environment.GetEnvironmentVariable("EXCEPTIONLESS_SERVER_URL") ?? DefaultServerUrl;
+            config.IncludePrivateInformation = false;
+            config.DefaultTags.Add("maui");
+            config.DefaultTags.Add("sample");
+            config.DefaultData["Platform"] = DeviceInfo.Current.Platform.ToString();
+            config.DefaultData["DeviceIdiom"] = DeviceInfo.Current.Idiom.ToString();
+            config.SetVersion(AppInfo.Current.VersionString);
+            config.UseFolderStorage(Path.Combine(appDataDirectory, "exceptionless-queue"));
+            config.UseFileLogger(Path.Combine(appDataDirectory, "exceptionless-client.log"), LogLevel.Info);
+        });
+
+        client.Startup();
+        return client;
+    }
+}

--- a/samples/Exceptionless.SampleMaui/MauiProgram.cs
+++ b/samples/Exceptionless.SampleMaui/MauiProgram.cs
@@ -35,8 +35,8 @@ public static class MauiProgram {
             config.DefaultData["Platform"] = DeviceInfo.Current.Platform.ToString();
             config.DefaultData["DeviceIdiom"] = DeviceInfo.Current.Idiom.ToString();
             config.SetVersion(AppInfo.Current.VersionString);
-            config.UseFolderStorage(Path.Combine(appDataDirectory, "exceptionless-queue"));
-            config.UseFileLogger(Path.Combine(appDataDirectory, "exceptionless-client.log"), LogLevel.Info);
+            config.UseFolderStorage(Path.Join(appDataDirectory, "exceptionless-queue"));
+            config.UseFileLogger(Path.Join(appDataDirectory, "exceptionless-client.log"), LogLevel.Info);
         });
 
         client.Startup();

--- a/samples/Exceptionless.SampleMaui/MauiProgram.cs
+++ b/samples/Exceptionless.SampleMaui/MauiProgram.cs
@@ -16,6 +16,8 @@ public static class MauiProgram {
             .UseMauiApp<App>();
 
         builder.Services.AddSingleton(exceptionlessClient);
+        builder.Services.AddSingleton<SampleEventService>();
+        builder.Services.AddSingleton<SampleDogfoodRunner>();
         builder.Services.AddSingleton<MainPage>();
 
         return builder.Build();

--- a/samples/Exceptionless.SampleMaui/MauiProgram.cs
+++ b/samples/Exceptionless.SampleMaui/MauiProgram.cs
@@ -6,7 +6,8 @@ namespace Exceptionless.SampleMaui;
 
 public static class MauiProgram {
     private const string DefaultApiKey = "LhhP1C9gijpSKCslHHCvwdSIz298twx271nTest";
-    private const string DefaultServerUrl = "https://ex.dev.localhost:7111";
+    private const string DefaultServerUrl = "http://localhost:7110";
+    private const string AndroidEmulatorServerUrl = "http://10.0.2.2:7110";
 
     public static MauiApp CreateMauiApp() {
         var builder = MauiApp.CreateBuilder();
@@ -28,7 +29,7 @@ public static class MauiProgram {
 
         var client = new ExceptionlessClient(config => {
             config.ApiKey = Environment.GetEnvironmentVariable("EXCEPTIONLESS_API_KEY") ?? DefaultApiKey;
-            config.ServerUrl = Environment.GetEnvironmentVariable("EXCEPTIONLESS_SERVER_URL") ?? DefaultServerUrl;
+            config.ServerUrl = GetServerUrl();
             config.IncludePrivateInformation = false;
             config.DefaultTags.Add("maui");
             config.DefaultTags.Add("sample");
@@ -41,5 +42,15 @@ public static class MauiProgram {
 
         client.Startup();
         return client;
+    }
+
+    private static string GetServerUrl() {
+        string? configuredServerUrl = Environment.GetEnvironmentVariable("EXCEPTIONLESS_SERVER_URL");
+        if (!String.IsNullOrWhiteSpace(configuredServerUrl))
+            return configuredServerUrl;
+
+        return DeviceInfo.Current.Platform == DevicePlatform.Android && DeviceInfo.Current.DeviceType == DeviceType.Virtual
+            ? AndroidEmulatorServerUrl
+            : DefaultServerUrl;
     }
 }

--- a/samples/Exceptionless.SampleMaui/Platforms/Android/AndroidManifest.xml
+++ b/samples/Exceptionless.SampleMaui/Platforms/Android/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true" />
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+  <uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/samples/Exceptionless.SampleMaui/Platforms/Android/AndroidManifest.xml
+++ b/samples/Exceptionless.SampleMaui/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-  <application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true" />
+  <application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true" android:usesCleartextTraffic="true" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/samples/Exceptionless.SampleMaui/Platforms/Android/MainActivity.cs
+++ b/samples/Exceptionless.SampleMaui/Platforms/Android/MainActivity.cs
@@ -1,0 +1,8 @@
+using Android.App;
+using Android.Content.PM;
+
+namespace Exceptionless.SampleMaui;
+
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+public class MainActivity : MauiAppCompatActivity {
+}

--- a/samples/Exceptionless.SampleMaui/Platforms/Android/MainApplication.cs
+++ b/samples/Exceptionless.SampleMaui/Platforms/Android/MainApplication.cs
@@ -1,0 +1,12 @@
+using Android.App;
+using Android.Runtime;
+
+namespace Exceptionless.SampleMaui;
+
+[Application]
+public class MainApplication : MauiApplication {
+    public MainApplication(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership) {
+    }
+
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/samples/Exceptionless.SampleMaui/Platforms/MacCatalyst/AppDelegate.cs
+++ b/samples/Exceptionless.SampleMaui/Platforms/MacCatalyst/AppDelegate.cs
@@ -1,0 +1,8 @@
+using Foundation;
+
+namespace Exceptionless.SampleMaui;
+
+[Register("AppDelegate")]
+public class AppDelegate : MauiUIApplicationDelegate {
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/samples/Exceptionless.SampleMaui/Platforms/MacCatalyst/Entitlements.plist
+++ b/samples/Exceptionless.SampleMaui/Platforms/MacCatalyst/Entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.app-sandbox</key>
+  <true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
+</dict>
+</plist>

--- a/samples/Exceptionless.SampleMaui/Platforms/MacCatalyst/Info.plist
+++ b/samples/Exceptionless.SampleMaui/Platforms/MacCatalyst/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>UIDeviceFamily</key>
+  <array>
+    <integer>2</integer>
+  </array>
+  <key>LSApplicationCategoryType</key>
+  <string>public.app-category.developer-tools</string>
+  <key>UIRequiredDeviceCapabilities</key>
+  <array>
+    <string>arm64</string>
+  </array>
+  <key>UISupportedInterfaceOrientations</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+  </array>
+  <key>UISupportedInterfaceOrientations~ipad</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+    <string>UIInterfaceOrientationPortraitUpsideDown</string>
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+  </array>
+  <key>XSAppIconAssets</key>
+  <string>Assets.xcassets/appicon.appiconset</string>
+</dict>
+</plist>

--- a/samples/Exceptionless.SampleMaui/Platforms/MacCatalyst/Program.cs
+++ b/samples/Exceptionless.SampleMaui/Platforms/MacCatalyst/Program.cs
@@ -1,0 +1,9 @@
+using UIKit;
+
+namespace Exceptionless.SampleMaui;
+
+public static class Program {
+    private static void Main(string[] args) {
+        UIApplication.Main(args, null, typeof(AppDelegate));
+    }
+}

--- a/samples/Exceptionless.SampleMaui/Platforms/Windows/App.xaml
+++ b/samples/Exceptionless.SampleMaui/Platforms/Windows/App.xaml
@@ -1,0 +1,7 @@
+<maui:MauiWinUIApplication
+    x:Class="Exceptionless.SampleMaui.WinUI.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:maui="using:Microsoft.Maui"
+    xmlns:local="using:Exceptionless.SampleMaui.WinUI">
+</maui:MauiWinUIApplication>

--- a/samples/Exceptionless.SampleMaui/Platforms/Windows/App.xaml.cs
+++ b/samples/Exceptionless.SampleMaui/Platforms/Windows/App.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.UI.Xaml;
+
+namespace Exceptionless.SampleMaui.WinUI;
+
+public partial class App : MauiWinUIApplication {
+    public App() {
+        InitializeComponent();
+    }
+
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/samples/Exceptionless.SampleMaui/Platforms/Windows/Package.appxmanifest
+++ b/samples/Exceptionless.SampleMaui/Platforms/Windows/Package.appxmanifest
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
+
+  <Identity Name="Exceptionless.SampleMaui" Publisher="CN=Exceptionless" Version="1.0.0.0" />
+
+  <Properties>
+    <DisplayName>Exceptionless MAUI Sample</DisplayName>
+    <PublisherDisplayName>Exceptionless</PublisherDisplayName>
+    <Logo>appiconStoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
+
+  <Applications>
+    <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="$targetentrypoint$">
+      <uap:VisualElements
+        DisplayName="Exceptionless MAUI Sample"
+        Description="Exceptionless MAUI Sample"
+        Square150x150Logo="appiconMediumTile.png"
+        Square44x44Logo="appiconLogo.png"
+        BackgroundColor="#3A6EA5">
+        <uap:DefaultTile Square71x71Logo="appiconSmallTile.png" Wide310x150Logo="appiconWideTile.png" Square310x310Logo="appiconLargeTile.png" />
+        <uap:SplashScreen Image="splashSplashScreen.png" />
+      </uap:VisualElements>
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <Capability Name="internetClient" />
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+</Package>

--- a/samples/Exceptionless.SampleMaui/Platforms/Windows/app.manifest
+++ b/samples/Exceptionless.SampleMaui/Platforms/Windows/app.manifest
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="Exceptionless.SampleMaui.WinUI.app" />
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/samples/Exceptionless.SampleMaui/Platforms/iOS/AppDelegate.cs
+++ b/samples/Exceptionless.SampleMaui/Platforms/iOS/AppDelegate.cs
@@ -1,0 +1,8 @@
+using Foundation;
+
+namespace Exceptionless.SampleMaui;
+
+[Register("AppDelegate")]
+public class AppDelegate : MauiUIApplicationDelegate {
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/samples/Exceptionless.SampleMaui/Platforms/iOS/Info.plist
+++ b/samples/Exceptionless.SampleMaui/Platforms/iOS/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>LSRequiresIPhoneOS</key>
+  <true/>
+  <key>UIDeviceFamily</key>
+  <array>
+    <integer>1</integer>
+    <integer>2</integer>
+  </array>
+  <key>UIRequiredDeviceCapabilities</key>
+  <array>
+    <string>arm64</string>
+  </array>
+  <key>UISupportedInterfaceOrientations</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+  </array>
+  <key>UISupportedInterfaceOrientations~ipad</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+    <string>UIInterfaceOrientationPortraitUpsideDown</string>
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+  </array>
+  <key>XSAppIconAssets</key>
+  <string>Assets.xcassets/appicon.appiconset</string>
+</dict>
+</plist>

--- a/samples/Exceptionless.SampleMaui/Platforms/iOS/Program.cs
+++ b/samples/Exceptionless.SampleMaui/Platforms/iOS/Program.cs
@@ -1,0 +1,9 @@
+using UIKit;
+
+namespace Exceptionless.SampleMaui;
+
+public static class Program {
+    private static void Main(string[] args) {
+        UIApplication.Main(args, null, typeof(AppDelegate));
+    }
+}

--- a/samples/Exceptionless.SampleMaui/README.md
+++ b/samples/Exceptionless.SampleMaui/README.md
@@ -1,0 +1,32 @@
+# Exceptionless MAUI Sample
+
+This sample uses the core `Exceptionless` client from a .NET MAUI app. There is no MAUI-specific Exceptionless package, so the app registers an `ExceptionlessClient` in MAUI dependency injection and submits handled exceptions, log events, and feature-usage events from the main page.
+
+## Configuration
+
+The sample defaults to the same local development server used by the other samples:
+
+- API key: `LhhP1C9gijpSKCslHHCvwdSIz298twx271nTest`
+- Server URL: `https://ex.dev.localhost:7111`
+
+Override either value with environment variables before launch:
+
+```bash
+export EXCEPTIONLESS_API_KEY="YOUR_API_KEY"
+export EXCEPTIONLESS_SERVER_URL="https://collector.exceptionless.io"
+```
+
+Events are queued under `FileSystem.Current.AppDataDirectory`, `IncludePrivateInformation` is disabled, and the sample has an explicit **Flush Queue** action. The app also asks the client to process the queue when the MAUI application goes to sleep.
+
+## Run
+
+Install the MAUI workload for the .NET SDK used by this repository, then run a target supported by your machine:
+
+```bash
+dotnet workload install maui
+dotnet build samples/Exceptionless.SampleMaui/Exceptionless.SampleMaui.csproj -f net10.0-maccatalyst
+dotnet build samples/Exceptionless.SampleMaui/Exceptionless.SampleMaui.csproj -f net10.0-ios
+dotnet build samples/Exceptionless.SampleMaui/Exceptionless.SampleMaui.csproj -f net10.0-android
+```
+
+Android emulators cannot usually reach a host machine's `localhost` address directly. If you are sending to a local Exceptionless server from Android, use a URL that the emulator can reach and make sure the development certificate is trusted.

--- a/samples/Exceptionless.SampleMaui/README.md
+++ b/samples/Exceptionless.SampleMaui/README.md
@@ -4,10 +4,11 @@ This sample uses the core `Exceptionless` client from a .NET MAUI app. There is 
 
 ## Configuration
 
-The sample defaults to the same local development server used by the other samples:
+The sample defaults to the local development server used by the mobile samples:
 
 - API key: `LhhP1C9gijpSKCslHHCvwdSIz298twx271nTest`
-- Server URL: `https://ex.dev.localhost:7111`
+- iOS, Mac Catalyst, and Windows server URL: `http://localhost:7110`
+- Android emulator server URL: `http://10.0.2.2:7110`
 
 Override either value with environment variables before launch:
 
@@ -22,9 +23,9 @@ Use **Refresh Config** to force a project configuration fetch. The page shows th
 
 For command-line dogfooding, set `EXCEPTIONLESS_SAMPLE_AUTORUN=true` and optionally `EXCEPTIONLESS_SAMPLE_AUTORUN_RESULT_PATH` before launching the app. Autorun refreshes project configuration, submits a handled exception, submits a warning log, tracks feature usage, flushes the queue, and writes a small result file when a result path is supplied.
 
-## Run
+## Build And Run
 
-Install the MAUI workload for the .NET SDK used by this repository, then run a target supported by your machine:
+Install the MAUI workload for the .NET SDK used by this repository, then build a target supported by your machine:
 
 ```bash
 dotnet workload install maui
@@ -33,4 +34,10 @@ dotnet build samples/Exceptionless.SampleMaui/Exceptionless.SampleMaui.csproj -f
 dotnet build samples/Exceptionless.SampleMaui/Exceptionless.SampleMaui.csproj -f net10.0-android
 ```
 
-Android emulators cannot usually reach a host machine's `localhost` address directly. If you are sending to a local Exceptionless server from Android, use a URL that the emulator can reach and make sure the development certificate is trusted.
+Launch the Mac Catalyst target from the command line with:
+
+```bash
+dotnet build samples/Exceptionless.SampleMaui/Exceptionless.SampleMaui.csproj -t:Run -f net10.0-maccatalyst
+```
+
+Physical Android devices cannot reach the host machine through `10.0.2.2`. Set `EXCEPTIONLESS_SERVER_URL` to an HTTP URL containing the development machine's LAN address when running on a physical device.

--- a/samples/Exceptionless.SampleMaui/README.md
+++ b/samples/Exceptionless.SampleMaui/README.md
@@ -18,6 +18,10 @@ export EXCEPTIONLESS_SERVER_URL="https://collector.exceptionless.io"
 
 Events are queued under `FileSystem.Current.AppDataDirectory`, `IncludePrivateInformation` is disabled, and the sample has an explicit **Flush Queue** action. The app also asks the client to process the queue when the MAUI application goes to sleep.
 
+Use **Refresh Config** to force a project configuration fetch. The page shows the `SampleMaui.ConfigValue` server setting after it is loaded.
+
+For command-line dogfooding, set `EXCEPTIONLESS_SAMPLE_AUTORUN=true` and optionally `EXCEPTIONLESS_SAMPLE_AUTORUN_RESULT_PATH` before launching the app. Autorun refreshes project configuration, submits a handled exception, submits a warning log, tracks feature usage, flushes the queue, and writes a small result file when a result path is supplied.
+
 ## Run
 
 Install the MAUI workload for the .NET SDK used by this repository, then run a target supported by your machine:

--- a/samples/Exceptionless.SampleMaui/Resources/AppIcon/appicon.svg
+++ b/samples/Exceptionless.SampleMaui/Resources/AppIcon/appicon.svg
@@ -1,0 +1,6 @@
+<svg width="456" height="456" viewBox="0 0 456 456" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="456" height="456" rx="84" fill="#3A6EA5"/>
+  <circle cx="228" cy="228" r="132" fill="#FFFFFF"/>
+  <path d="M158 252c18 38 56 62 99 58 42-5 76-35 87-76" stroke="#1F4D72" stroke-width="28" stroke-linecap="round"/>
+  <path d="M144 204c10-43 46-76 91-80 43-4 83 20 101 57" stroke="#1F4D72" stroke-width="28" stroke-linecap="round"/>
+</svg>

--- a/samples/Exceptionless.SampleMaui/Resources/AppIcon/appiconfg.svg
+++ b/samples/Exceptionless.SampleMaui/Resources/AppIcon/appiconfg.svg
@@ -1,0 +1,5 @@
+<svg width="456" height="456" viewBox="0 0 456 456" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="228" cy="228" r="132" fill="#FFFFFF"/>
+  <path d="M158 252c18 38 56 62 99 58 42-5 76-35 87-76" stroke="#1F4D72" stroke-width="28" stroke-linecap="round"/>
+  <path d="M144 204c10-43 46-76 91-80 43-4 83 20 101 57" stroke="#1F4D72" stroke-width="28" stroke-linecap="round"/>
+</svg>

--- a/samples/Exceptionless.SampleMaui/Resources/Splash/splash.svg
+++ b/samples/Exceptionless.SampleMaui/Resources/Splash/splash.svg
@@ -1,0 +1,5 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="64" cy="64" r="48" fill="#FFFFFF"/>
+  <path d="M38 72c7 15 21 24 37 22 16-1 29-13 34-28" stroke="#1F4D72" stroke-width="10" stroke-linecap="round"/>
+  <path d="M34 54c4-16 18-28 35-30 16-1 31 8 38 22" stroke="#1F4D72" stroke-width="10" stroke-linecap="round"/>
+</svg>

--- a/samples/Exceptionless.SampleMaui/SampleDogfoodRunner.cs
+++ b/samples/Exceptionless.SampleMaui/SampleDogfoodRunner.cs
@@ -17,8 +17,8 @@ public sealed class SampleDogfoodRunner {
             await _sampleEvents.RefreshProjectConfigurationAsync();
             string configValue = _sampleEvents.GetSampleConfigValue();
             string exceptionReferenceId = _sampleEvents.SubmitHandledException();
-            string? logReferenceId = _sampleEvents.SubmitWarningLog();
-            string? featureReferenceId = _sampleEvents.TrackFeatureUsage();
+            string logReferenceId = _sampleEvents.SubmitWarningLog();
+            string featureReferenceId = _sampleEvents.TrackFeatureUsage();
             await _sampleEvents.FlushQueueAsync();
 
             WriteResult(resultPath,
@@ -41,8 +41,10 @@ public sealed class SampleDogfoodRunner {
         // Autorun should still exercise the client if a platform sandbox rejects the result path.
         try {
             File.WriteAllLines(path, lines);
-        } catch (IOException) {
-        } catch (UnauthorizedAccessException) {
+        } catch (IOException ex) {
+            System.Diagnostics.Debug.WriteLine($"Unable to write Exceptionless MAUI sample dogfood result: {ex}");
+        } catch (UnauthorizedAccessException ex) {
+            System.Diagnostics.Debug.WriteLine($"Unable to write Exceptionless MAUI sample dogfood result: {ex}");
         }
     }
 }

--- a/samples/Exceptionless.SampleMaui/SampleDogfoodRunner.cs
+++ b/samples/Exceptionless.SampleMaui/SampleDogfoodRunner.cs
@@ -1,0 +1,48 @@
+namespace Exceptionless.SampleMaui;
+
+public sealed class SampleDogfoodRunner {
+    private readonly SampleEventService _sampleEvents;
+
+    public SampleDogfoodRunner(SampleEventService sampleEvents) {
+        _sampleEvents = sampleEvents;
+    }
+
+    public async Task RunIfRequestedAsync() {
+        if (!String.Equals(Environment.GetEnvironmentVariable("EXCEPTIONLESS_SAMPLE_AUTORUN"), "true", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        string? resultPath = Environment.GetEnvironmentVariable("EXCEPTIONLESS_SAMPLE_AUTORUN_RESULT_PATH");
+
+        try {
+            await _sampleEvents.RefreshProjectConfigurationAsync();
+            string configValue = _sampleEvents.GetSampleConfigValue();
+            string exceptionReferenceId = _sampleEvents.SubmitHandledException();
+            string? logReferenceId = _sampleEvents.SubmitWarningLog();
+            string? featureReferenceId = _sampleEvents.TrackFeatureUsage();
+            await _sampleEvents.FlushQueueAsync();
+
+            WriteResult(resultPath,
+                "status=completed",
+                $"config.{SampleEventService.SampleConfigSettingKey}={configValue}",
+                $"handledExceptionReferenceId={exceptionReferenceId}",
+                $"logReferenceId={logReferenceId}",
+                $"featureReferenceId={featureReferenceId}");
+        } catch (InvalidOperationException ex) {
+            WriteResult(resultPath, "status=failed", $"error={ex.Message}");
+        } catch (TaskCanceledException ex) {
+            WriteResult(resultPath, "status=failed", $"error={ex.Message}");
+        }
+    }
+
+    private static void WriteResult(string? path, params string[] lines) {
+        if (String.IsNullOrWhiteSpace(path))
+            return;
+
+        // Autorun should still exercise the client if a platform sandbox rejects the result path.
+        try {
+            File.WriteAllLines(path, lines);
+        } catch (IOException) {
+        } catch (UnauthorizedAccessException) {
+        }
+    }
+}

--- a/samples/Exceptionless.SampleMaui/SampleEventService.cs
+++ b/samples/Exceptionless.SampleMaui/SampleEventService.cs
@@ -28,14 +28,24 @@ public sealed class SampleEventService {
         return referenceId;
     }
 
-    public string? SubmitWarningLog() {
-        _exceptionlessClient.SubmitLog("Exceptionless.SampleMaui.MainPage", "MAUI sample warning log.", LogLevel.Warn);
-        return _exceptionlessClient.GetLastReferenceId();
+    public string SubmitWarningLog() {
+        string referenceId = Guid.NewGuid().ToString("N");
+
+        _exceptionlessClient.CreateLog("Exceptionless.SampleMaui.MainPage", "MAUI sample warning log.", LogLevel.Warn)
+            .SetReferenceId(referenceId)
+            .Submit();
+
+        return referenceId;
     }
 
-    public string? TrackFeatureUsage() {
-        _exceptionlessClient.SubmitFeatureUsage("MauiSample.TrackFeature");
-        return _exceptionlessClient.GetLastReferenceId();
+    public string TrackFeatureUsage() {
+        string referenceId = Guid.NewGuid().ToString("N");
+
+        _exceptionlessClient.CreateFeatureUsage("MauiSample.TrackFeature")
+            .SetReferenceId(referenceId)
+            .Submit();
+
+        return referenceId;
     }
 
     public async Task RefreshProjectConfigurationAsync() {

--- a/samples/Exceptionless.SampleMaui/SampleEventService.cs
+++ b/samples/Exceptionless.SampleMaui/SampleEventService.cs
@@ -1,0 +1,52 @@
+using Exceptionless.Configuration;
+using Exceptionless.Logging;
+
+namespace Exceptionless.SampleMaui;
+
+public sealed class SampleEventService {
+    public const string SampleConfigSettingKey = "SampleMaui.ConfigValue";
+
+    private readonly ExceptionlessClient _exceptionlessClient;
+
+    public SampleEventService(ExceptionlessClient exceptionlessClient) {
+        _exceptionlessClient = exceptionlessClient;
+    }
+
+    public string SubmitHandledException() {
+        string referenceId = Guid.NewGuid().ToString("N");
+
+        try {
+            throw new InvalidOperationException("Exceptionless MAUI sample handled exception.");
+        } catch (InvalidOperationException ex) {
+            ex.ToExceptionless(_exceptionlessClient)
+                .SetReferenceId(referenceId)
+                .AddTags("handled")
+                .SetProperty("Screen", nameof(MainPage))
+                .Submit();
+        }
+
+        return referenceId;
+    }
+
+    public string? SubmitWarningLog() {
+        _exceptionlessClient.SubmitLog("Exceptionless.SampleMaui.MainPage", "MAUI sample warning log.", LogLevel.Warn);
+        return _exceptionlessClient.GetLastReferenceId();
+    }
+
+    public string? TrackFeatureUsage() {
+        _exceptionlessClient.SubmitFeatureUsage("MauiSample.TrackFeature");
+        return _exceptionlessClient.GetLastReferenceId();
+    }
+
+    public async Task RefreshProjectConfigurationAsync() {
+        await SettingsManager.UpdateSettingsAsync(_exceptionlessClient.Configuration, 0);
+    }
+
+    public Task FlushQueueAsync() {
+        return _exceptionlessClient.ProcessQueueAsync();
+    }
+
+    public string GetSampleConfigValue() {
+        return _exceptionlessClient.Configuration.Settings.GetString(SampleConfigSettingKey, "not loaded");
+    }
+}


### PR DESCRIPTION
## Summary

- Add `samples/Exceptionless.SampleMaui`, a .NET MAUI sample that uses the core `Exceptionless` client via MAUI DI.
- Configure app-data folder storage, file logging, default MAUI tags/data, app version, and `IncludePrivateInformation = false`.
- Resolve the local development server per platform: `http://localhost:7110` for iOS, Mac Catalyst, and Windows; `http://10.0.2.2:7110` for the Android emulator; and an environment override for physical devices or custom servers.
- Add sample UI actions for project configuration refresh, handled exceptions, warning logs, feature usage, and explicit queue flushing.
- Add a command-line autorun dogfood path that refreshes configuration, queues the sample events, flushes the queue, and can write a small result file.
- Add platform bootstrap files/manifests/assets plus README instructions for workloads, launching Mac Catalyst, and API key/server URL overrides.

Fixes #366

## Validation

- `dotnet build samples/Exceptionless.SampleMaui/Exceptionless.SampleMaui.csproj -f net10.0-maccatalyst -p:ValidateXcodeVersion=false`
- `dotnet build samples/Exceptionless.SampleMaui/Exceptionless.SampleMaui.csproj -c Release -f net10.0-maccatalyst -p:ValidateXcodeVersion=false -p:RuntimeIdentifier=maccatalyst-arm64`
- `dotnet build samples/Exceptionless.SampleMaui/Exceptionless.SampleMaui.csproj -c Release -f net10.0-ios -p:ValidateXcodeVersion=false -p:RuntimeIdentifier=iossimulator-arm64`
  - The iOS simulator Release output includes AOT artifacts such as `Exceptionless.aotdata.arm64` and `Exceptionless.SampleMaui.aotdata.arm64`.
- Launched the Mac Catalyst Release app locally with `EXCEPTIONLESS_SAMPLE_AUTORUN=true`, `EXCEPTIONLESS_API_KEY=TEST_API_KEY`, and `EXCEPTIONLESS_SERVER_URL=http://127.0.0.1:18181`.
  - A local collector stub received `GET /api/v2/projects/config?v=0`.
  - The stub then received `POST /api/v2/events` containing `usage` (`MauiSample.TrackFeature`, reference id `8c2dac9145584824bc67f0466131bc94`), `log` (`Exceptionless.SampleMaui.MainPage`, reference id `f788aa00d1b84271999a34ea3f902fa4`), and `error` (reference id `5bfd1b7325b94d2e96b45c6f73a84bb6`) events.
- Launched the Mac Catalyst app with `EXCEPTIONLESS_SAMPLE_AUTORUN=true` and no API key or server URL overrides against the real local Exceptionless AppHost.
  - `GET http://localhost:7110/api/v2/about` returned `200`.
  - The client started with `ServerUrl=http://localhost:7110` and logged `Sent 3 events to "http://localhost:7110"`.
  - `GET /api/v2/events?sort=-date&limit=10` showed the submitted MAUI events: `usage` (`MauiSample.TrackFeature`, reference id `a47a106724d0476285935e8f36548f4a`), `log` (`Exceptionless.SampleMaui.MainPage`, reference id `3a032ef3f2044e01a19b1818809ebdea`), and `error` (`Exceptionless MAUI sample handled exception.`, reference id `2b11511070f942fb9cf48e42376ef6cf`).
- `dotnet build Exceptionless.Net.NonWindows.slnx`
- `dotnet test Exceptionless.Net.NonWindows.slnx --no-build`

## Local MAUI Toolchain Notes

- Ordinary `net10.0-maccatalyst` builds are blocked on this machine because the installed .NET Mac Catalyst pack `26.5.10284` requires Xcode `26.5`, while this machine has Xcode `26.6`. The local validation above uses `-p:ValidateXcodeVersion=false` for that reason.
- `net10.0-android` builds are blocked on this machine by missing Android SDK/JDK configuration: `XA5300: The Android SDK directory could not be found`.
- Launching the Mac Catalyst app emits a non-blocking UIKit background-fetch warning from the MAUI app host, but config refresh and event submission still complete.
