### PR TITLE
Update dependencies and fix concurrent settings initialization

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/dotnet:2.5.0": {
+      "version": "2.5.0",
+      "resolved": "ghcr.io/devcontainers/features/dotnet@sha256:0fc16547ed4db6d7ff2a9f5981d2b93eb314e568affb9958029ad794f1f9a093",
+      "integrity": "sha256:0fc16547ed4db6d7ff2a9f5981d2b93eb314e568affb9958029ad794f1f9a093"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "image": "mcr.microsoft.com/devcontainers/dotnet:2.1.4-10.0-noble",
   "features": {
     "ghcr.io/devcontainers/features/dotnet:2.5.0": {
-      "version": "10.0.400"
+      "version": "10.0"
     }
   },
   "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
 
   "name": "Exceptionless.Net",
-  "image": "mcr.microsoft.com/devcontainers/dotnet:2.1.4-10.0-noble",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:2.2.2-10.0-noble",
   "features": {
     "ghcr.io/devcontainers/features/dotnet:2.5.0": {
       "version": "10.0"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
 
   "name": "Exceptionless.Net",
-  "image": "mcr.microsoft.com/vscode/devcontainers/dotnetcore:latest",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:2.1.4-10.0-noble",
   "extensions": [
     "ms-dotnettools.csharp",
     "streetsidesoftware.code-spell-checker",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,11 @@
 
   "name": "Exceptionless.Net",
   "image": "mcr.microsoft.com/devcontainers/dotnet:2.1.4-10.0-noble",
+  "features": {
+    "ghcr.io/devcontainers/features/dotnet:2.5.0": {
+      "version": "10.0.400"
+    }
+  },
   "extensions": [
     "ms-dotnettools.csharp",
     "streetsidesoftware.code-spell-checker",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,17 @@ updates:
     semver-major-days: 7
     semver-minor-days: 7
     semver-patch-days: 7
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  cooldown:
+    default-days: 7
+
+- package-ecosystem: devcontainers
+  directory: "/"
+  schedule:
+    interval: weekly
+  cooldown:
+    default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,10 @@ updates:
     interval: weekly
   cooldown:
     default-days: 7
+
+- package-ecosystem: dotnet-sdk
+  directory: "/"
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 1

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         persist-credentials: false
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+      uses: actions/setup-dotnet@v6
       with:
         global-json-file: global.json
     - name: Build Reason

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -3,6 +3,8 @@ on: [push, pull_request]
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_NOLOGO: 1
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -11,6 +13,7 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         global-json-file: global.json
     - name: Build Reason
@@ -20,7 +20,7 @@ jobs:
     - name: Build Version
       shell: bash
       run: |
-        dotnet tool install --global minver-cli --version 6.0.0
+        dotnet tool install --global minver-cli --version 7.0.0
         version=$(minver --tag-prefix v)
         echo "MINVERVERSIONOVERRIDE=$version" >> $GITHUB_ENV
     - name: Build

--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: macOS-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         global-json-file: global.json
     - name: Build Reason
@@ -20,7 +20,7 @@ jobs:
     - name: Build Version
       shell: bash
       run: |
-        dotnet tool install --global minver-cli --version 6.0.0
+        dotnet tool install --global minver-cli --version 7.0.0
         version=$(minver --tag-prefix v)
         echo "MINVERVERSIONOVERRIDE=$version" >> $GITHUB_ENV
     - name: Build

--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: macOS-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         persist-credentials: false
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+      uses: actions/setup-dotnet@v6
       with:
         global-json-file: global.json
     - name: Build Reason

--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -3,6 +3,8 @@ on: [push, pull_request]
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_NOLOGO: 1
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: macOS-latest
@@ -11,6 +13,7 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         global-json-file: global.json
     - name: Build Reason
@@ -20,7 +20,7 @@ jobs:
     - name: Build Version
       shell: bash
       run: |
-        dotnet tool install --global minver-cli --version 6.0.0
+        dotnet tool install --global minver-cli --version 7.0.0
         version=$(minver --tag-prefix v)
         echo "MINVERVERSIONOVERRIDE=$version" >> $GITHUB_ENV
     - name: Build
@@ -32,7 +32,7 @@ jobs:
       run: dotnet pack --configuration Release --no-build Exceptionless.Net.Windows.slnx
     - name: Install GitHub Package Tool
       if: github.event_name != 'pull_request'
-      run: dotnet tool install gpr -g
+      run: dotnet tool install --global gpr --version 0.1.294
     - name: Publish CI Packages
       shell: bash
       if: github.event_name != 'pull_request'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -42,7 +42,7 @@ jobs:
           echo "${0##*/}": Pushing $package...
 
           # GitHub
-          dotnet nuget push "$package" --source https://nuget.pkg.github.com/Exceptionless/index.json --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
+          dotnet nuget push "$package" --source https://nuget.pkg.github.com/Exceptionless/index.json --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate || true
 
           # Feedz (remove once GitHub supports anonymous access)
           dotnet nuget push $package --source https://f.feedz.io/exceptionless/exceptionless/nuget --api-key ${{ secrets.FEEDZ_KEY }} --skip-duplicate

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -38,20 +38,20 @@ jobs:
       shell: bash
       if: github.event_name != 'pull_request'
       run: |
-        for package in $(find -name "*.nupkg" | grep "minver" -v); do
+        while IFS= read -r -d '' package; do
           echo "${0##*/}": Pushing $package...
 
           # GitHub
           dotnet nuget push "$package" --source https://nuget.pkg.github.com/Exceptionless/index.json --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate || true
 
           # Feedz (remove once GitHub supports anonymous access)
-          dotnet nuget push $package --source https://f.feedz.io/exceptionless/exceptionless/nuget --api-key ${{ secrets.FEEDZ_KEY }} --skip-duplicate
-        done
+          dotnet nuget push "$package" --source https://f.feedz.io/exceptionless/exceptionless/nuget --api-key ${{ secrets.FEEDZ_KEY }} --skip-duplicate
+        done < <(find . -name '*.nupkg' ! -path '*minver*' -print0)
     - name: Publish Release Packages
       shell: bash
       if: startsWith(github.ref, 'refs/tags/v')
       run: |
-        for package in $(find -name "*.nupkg" | grep "minver" -v); do
+        while IFS= read -r -d '' package; do
           echo "${0##*/}": Pushing $package...
-          dotnet nuget push $package --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_KEY }} --skip-duplicate
-        done
+          dotnet nuget push "$package" --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_KEY }} --skip-duplicate
+        done < <(find . -name '*.nupkg' ! -path '*minver*' -print0)

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -3,6 +3,9 @@ on: [push, pull_request]
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_NOLOGO: 1
+permissions:
+  contents: read
+  packages: write
 jobs:
   build:
     runs-on: windows-latest
@@ -11,6 +14,7 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
@@ -30,9 +34,6 @@ jobs:
     - name: Package
       if: github.event_name != 'pull_request'
       run: dotnet pack --configuration Release --no-build Exceptionless.Net.Windows.slnx
-    - name: Install GitHub Package Tool
-      if: github.event_name != 'pull_request'
-      run: dotnet tool install --global gpr --version 0.1.294
     - name: Publish CI Packages
       shell: bash
       if: github.event_name != 'pull_request'
@@ -41,7 +42,7 @@ jobs:
           echo "${0##*/}": Pushing $package...
 
           # GitHub
-          gpr push $package -k ${{ secrets.GITHUB_TOKEN }} || true
+          dotnet nuget push "$package" --source https://nuget.pkg.github.com/Exceptionless/index.json --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
 
           # Feedz (remove once GitHub supports anonymous access)
           dotnet nuget push $package --source https://f.feedz.io/exceptionless/exceptionless/nuget --api-key ${{ secrets.FEEDZ_KEY }} --skip-duplicate

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         persist-credentials: false
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+      uses: actions/setup-dotnet@v6
       with:
         global-json-file: global.json
     - name: Build Reason

--- a/build/common.props
+++ b/build/common.props
@@ -41,7 +41,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400" PrivateAssets="All"/>
     <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/build/common.props
+++ b/build/common.props
@@ -41,7 +41,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All"/>
     <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.302",
     "rollForward": "latestMinor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.302",
+    "version": "10.0.400",
     "rollForward": "latestMinor"
   }
 }

--- a/samples/Exceptionless.SampleBlazorWebAssemblyApp/Exceptionless.SampleBlazorWebAssemblyApp.csproj
+++ b/samples/Exceptionless.SampleBlazorWebAssemblyApp/Exceptionless.SampleBlazorWebAssemblyApp.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Exceptionless.SampleBlazorWebAssemblyApp/Exceptionless.SampleBlazorWebAssemblyApp.csproj
+++ b/samples/Exceptionless.SampleBlazorWebAssemblyApp/Exceptionless.SampleBlazorWebAssemblyApp.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.11" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Exceptionless.SampleLambda/Exceptionless.SampleLambda.csproj
+++ b/samples/Exceptionless.SampleLambda/Exceptionless.SampleLambda.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="3.3.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Exceptionless.SampleLambda/Exceptionless.SampleLambda.csproj
+++ b/samples/Exceptionless.SampleLambda/Exceptionless.SampleLambda.csproj
@@ -8,7 +8,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="3.1.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="3.3.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.0" />
   </ItemGroup>
 

--- a/samples/Exceptionless.SampleLambdaAspNetCore/Exceptionless.SampleLambdaAspNetCore.csproj
+++ b/samples/Exceptionless.SampleLambdaAspNetCore/Exceptionless.SampleLambdaAspNetCore.csproj
@@ -5,8 +5,8 @@
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.4.7" />
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="10.1.1" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.100.7" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="10.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Platforms\Exceptionless.AspNetCore\Exceptionless.AspNetCore.csproj" />

--- a/samples/Exceptionless.SampleLambdaAspNetCore/Exceptionless.SampleLambdaAspNetCore.csproj
+++ b/samples/Exceptionless.SampleLambdaAspNetCore/Exceptionless.SampleLambdaAspNetCore.csproj
@@ -5,8 +5,8 @@
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.100.8" />
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="10.2.0" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.101.1" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="10.2.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Platforms\Exceptionless.AspNetCore\Exceptionless.AspNetCore.csproj" />

--- a/samples/Exceptionless.SampleLambdaAspNetCore/Exceptionless.SampleLambdaAspNetCore.csproj
+++ b/samples/Exceptionless.SampleLambdaAspNetCore/Exceptionless.SampleLambdaAspNetCore.csproj
@@ -5,7 +5,7 @@
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.100.7" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.100.8" />
     <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="10.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Exceptionless/Exceptionless.csproj
+++ b/src/Exceptionless/Exceptionless.csproj
@@ -34,12 +34,12 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'" Label="Package References">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Metadata" Version="8.0.1" />
+    <PackageReference Include="System.Reflection.Metadata" Version="10.0.10" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>
 

--- a/src/Exceptionless/Exceptionless.csproj
+++ b/src/Exceptionless/Exceptionless.csproj
@@ -34,12 +34,12 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'" Label="Package References">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Metadata" Version="10.0.10" />
+    <PackageReference Include="System.Reflection.Metadata" Version="10.0.11" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>
 

--- a/src/Exceptionless/Models/Collections/SettingsDictionary.cs
+++ b/src/Exceptionless/Models/Collections/SettingsDictionary.cs
@@ -158,25 +158,6 @@ namespace Exceptionless.Models {
                     LogLevel value;
                     _minLogLevels.TryRemove(logger, out value);
                 }
-}
-
-            foreach (var eventType in _eventTypes) {
-                if (eventType.Key == null || !_typeSourceEnabled.TryGetValue(eventType.Key, out var sourceDictionary))
-                    continue;
-
-                if (!args.Item.Key.StartsWith(eventType.Value))
-                    continue;
-
-                var sourceKeysToRemove = new List<string>();
-                foreach (string key in sourceDictionary.Keys) {
-                    if (key.IsPatternMatch(args.Item.Key.Substring(eventType.Value.Length)))
-                        sourceKeysToRemove.Add(key);
-                }
-
-                foreach (var logger in sourceKeysToRemove) {
-                    bool value;
-                    sourceDictionary.TryRemove(logger, out value);
-                }
             }
 
             base.OnChanged(args);
@@ -202,16 +183,9 @@ namespace Exceptionless.Models {
             return minLogLevel;
         }
 
-        private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, bool>> _typeSourceEnabled = new ConcurrentDictionary<string, ConcurrentDictionary<string, bool>>(StringComparer.OrdinalIgnoreCase);
-
         public bool GetTypeAndSourceEnabled(string type, string source) {
             if (type == null)
                 return true;
-
-            if (source != null && _typeSourceEnabled.TryGetValue(type, out var sourceDictionary)) {
-                if (sourceDictionary.TryGetValue(source, out bool sourceEnabled))
-                    return sourceEnabled;
-            }
 
             return GetTypeAndSourceSetting(type, source, "true").ToBoolean(true);
         }
@@ -222,16 +196,7 @@ namespace Exceptionless.Models {
             if (type == null)
                 return defaultValue;
 
-            string sourcePrefix;
-            if (!_typeSourceEnabled.TryGetValue(type, out var sourceDictionary)) {
-                sourceDictionary = new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
-                _typeSourceEnabled.TryAdd(type, sourceDictionary);
-                sourcePrefix = "@@" + type + ":";
-
-                _eventTypes.TryAdd(type, sourcePrefix);
-            } else {
-                sourcePrefix = _eventTypes[type];
-            }
+            string sourcePrefix = _eventTypes.GetOrAdd(type, eventType => "@@" + eventType + ":");
 
             // check for exact source match
             if (TryGetValue(sourcePrefix + source, out string settingValue))

--- a/src/Platforms/Exceptionless.Extensions.Hosting/Exceptionless.Extensions.Hosting.csproj
+++ b/src/Platforms/Exceptionless.Extensions.Hosting/Exceptionless.Extensions.Hosting.csproj
@@ -19,11 +19,11 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References" Condition=" '$(TargetFramework)' == 'net9.0' ">
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.18" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.19" />
   </ItemGroup>
 
   <ItemGroup Label="Package References" Condition=" '$(TargetFramework)' == 'net10.0' ">
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platforms/Exceptionless.Extensions.Hosting/Exceptionless.Extensions.Hosting.csproj
+++ b/src/Platforms/Exceptionless.Extensions.Hosting/Exceptionless.Extensions.Hosting.csproj
@@ -15,15 +15,15 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References" Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup Label="Package References" Condition=" '$(TargetFramework)' == 'net9.0' ">
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.18" />
   </ItemGroup>
 
   <ItemGroup Label="Package References" Condition=" '$(TargetFramework)' == 'net10.0' ">
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platforms/Exceptionless.Extensions.Logging/Exceptionless.Extensions.Logging.csproj
+++ b/src/Platforms/Exceptionless.Extensions.Logging/Exceptionless.Extensions.Logging.csproj
@@ -15,15 +15,15 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References" Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup Label="Package References" Condition=" '$(TargetFramework)' == 'net9.0' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.18" />
   </ItemGroup>
 
   <ItemGroup Label="Package References" Condition=" '$(TargetFramework)' == 'net10.0' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platforms/Exceptionless.Extensions.Logging/Exceptionless.Extensions.Logging.csproj
+++ b/src/Platforms/Exceptionless.Extensions.Logging/Exceptionless.Extensions.Logging.csproj
@@ -19,11 +19,11 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References" Condition=" '$(TargetFramework)' == 'net9.0' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.18" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.19" />
   </ItemGroup>
 
   <ItemGroup Label="Package References" Condition=" '$(TargetFramework)' == 'net10.0' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platforms/Exceptionless.Log4net/Exceptionless.Log4net.csproj
+++ b/src/Platforms/Exceptionless.Log4net/Exceptionless.Log4net.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="log4net" Version="3.4.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' " Label="Build">

--- a/src/Platforms/Exceptionless.Log4net/Exceptionless.Log4net.csproj
+++ b/src/Platforms/Exceptionless.Log4net/Exceptionless.Log4net.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="log4net" Version="3.3.1" />
+    <PackageReference Include="log4net" Version="3.3.2" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' " Label="Build">

--- a/src/Platforms/Exceptionless.MessagePack/Exceptionless.MessagePack.csproj
+++ b/src/Platforms/Exceptionless.MessagePack/Exceptionless.MessagePack.csproj
@@ -25,6 +25,6 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="MessagePack" Version="3.1.7" />
+    <PackageReference Include="MessagePack" Version="3.1.8" />
   </ItemGroup>
 </Project>

--- a/src/Platforms/Exceptionless.NLog/Exceptionless.NLog.csproj
+++ b/src/Platforms/Exceptionless.NLog/Exceptionless.NLog.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="NLog" Version="6.1.3" />
+    <PackageReference Include="NLog" Version="6.1.4" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' " Label="Build">

--- a/src/Platforms/Exceptionless.NLog/Exceptionless.NLog.csproj
+++ b/src/Platforms/Exceptionless.NLog/Exceptionless.NLog.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="NLog" Version="6.1.4" />
+    <PackageReference Include="NLog" Version="6.2.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' " Label="Build">

--- a/test/Exceptionless.MessagePack.Tests/Exceptionless.MessagePack.Tests.csproj
+++ b/test/Exceptionless.MessagePack.Tests/Exceptionless.MessagePack.Tests.csproj
@@ -17,9 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit.v3.mtp-off" Version="4.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Exceptionless.MessagePack.Tests/Exceptionless.MessagePack.Tests.csproj
+++ b/test/Exceptionless.MessagePack.Tests/Exceptionless.MessagePack.Tests.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Exceptionless.TestHarness/Exceptionless.TestHarness.csproj
+++ b/test/Exceptionless.TestHarness/Exceptionless.TestHarness.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.v3.assert" Version="3.2.2" />
+    <PackageReference Include="xunit.v3.assert" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">

--- a/test/Exceptionless.Tests/Configuration/ConfigurationTests.cs
+++ b/test/Exceptionless.Tests/Configuration/ConfigurationTests.cs
@@ -166,21 +166,41 @@ namespace Exceptionless.Tests.Configuration {
 
         [Fact]
         public void CanGetLogSettingsMultithreaded() {
-            var settings = new SettingsDictionary {
-                { "@@log:*", "Info" },
-                { "@@log:Source1", "Trace" },
-                { "@@log:Source2", "Debug" },
-                { "@@log:Source3", "Info" },
-                { "@@log:Source4", "Info" }
-            };
+            for (int attempt = 0; attempt < 1000; attempt++) {
+                var settings = new SettingsDictionary {
+                    { "@@log:*", "Info" },
+                    { "@@log:Source1", "Trace" },
+                    { "@@log:Source2", "Debug" }
+                };
 
-            var result = Parallel.For(0, 100, index => {
-                var level = settings.GetMinLogLevel("Source1");
-                _writer.WriteLine("Source1 log level: {0}", level);
-            });
+                Parallel.For(0, 100, index => {
+                    Assert.Equal(LogLevel.Trace, settings.GetMinLogLevel("Source1"));
+                    Assert.Equal(LogLevel.Debug, settings.GetMinLogLevel("Source2"));
+                    Assert.Equal(LogLevel.Info, settings.GetMinLogLevel("Other"));
+                });
+            }
+        }
 
-            while (!result.IsCompleted)
-                Thread.Yield();
+        [Theory]
+        [InlineData("usage")]
+        [InlineData("error")]
+        public void CanGetEventSettingsMultithreaded(string type) {
+            for (int attempt = 0; attempt < 1000; attempt++) {
+                var settings = new SettingsDictionary {
+                    { "@@" + type + ":*", "true" },
+                    { "@@" + type + ":Source1", "false" }
+                };
+
+                Parallel.For(0, 100, index => {
+                    Assert.False(settings.GetTypeAndSourceEnabled(type, "Source1"));
+                    Assert.True(settings.GetTypeAndSourceEnabled(type, "Other"));
+                });
+
+                settings["@@" + type + ":Source1"] = "true";
+                Assert.True(settings.GetTypeAndSourceEnabled(type, "Source1"));
+                settings["@@" + type + ":*"] = "false";
+                Assert.False(settings.GetTypeAndSourceEnabled(type, "Other"));
+            }
         }
         
         [Fact]

--- a/test/Exceptionless.Tests/Exceptionless.Tests.csproj
+++ b/test/Exceptionless.Tests/Exceptionless.Tests.csproj
@@ -39,11 +39,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="xunit.v3.mtp-off" Version="4.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Exceptionless.Tests/Exceptionless.Tests.csproj
+++ b/test/Exceptionless.Tests/Exceptionless.Tests.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />

--- a/test/Exceptionless.Tests/Properties/AssemblyInfo.cs
+++ b/test/Exceptionless.Tests/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
-﻿using Xunit;
+﻿using Xunit.Sdk;
+using Xunit.v3;
 
-[assembly: CollectionBehavior(DisableTestParallelization = true, MaxParallelThreads = 1)]
+[assembly: Parallelization(Mode = ParallelMode.None)]


### PR DESCRIPTION
Refresh client, sample, and build dependencies, and replace the vulnerable `gpr` publishing tool with native NuGet publishing. Fix a settings-initialization race that could throw during concurrent logging by replacing two dependent cache writes with one atomic lookup and removing the unused cache. Public APIs and target frameworks are preserved.

Validation: six Linux/macOS/Windows CI builds passed; September 21 review passed 312 tests (18 existing skips), behavior comparisons, and refreshed NuGet/OSV security audits.

Compatibility: dependency minimums increase, and log4net 3.4 changes some appender timeout defaults. Legacy Windows sample builds/runtime, desktop interaction, and hosted AWS invocation remain unverified locally. One reviewer approval is required before merge.

<details><summary>Verification and implementation details</summary>

### Changes and rationale

- Update .NET SDK to 10.0.400, SourceLink to 10.0.400, core Configuration/Metadata packages to 10.0.11, MessagePack to 3.1.8, NLog to 6.2.0, log4net to 3.4.0, and AWS/Blazor sample dependencies. Hosting/logging integrations retain their matching Microsoft.Extensions 8/9/10 lines; net472 retains compatible RandomData 1.2.2.
- Update test SDK to 18.9.0 and xUnit to 4.0.0. The official `xunit.v3.mtp-off` package preserves VSTest and existing `dotnet test` commands. The new parallelization attribute preserves serial execution.
- Use `actions/checkout@v7` and `actions/setup-dotnet@v6`, restrict workflow permissions, and disable persisted checkout credentials. Add Dependabot coverage for Actions, Dev Container Features, and the SDK. Action major tags are intentionally mutable.
- Preserve GitHub publishing as best effort, required Feedz publishing, and tag-triggered NuGet releases. Both publish loops preserve package paths containing whitespace or wildcard characters. Removing `gpr` removes its embedded vulnerable Newtonsoft.Json/NuGet dependencies.
- Use the official versioned .NET devcontainer image and a locked Feature digest. `global.json` remains the SDK version owner.
- The removed settings cache never stored values. Its reads and invalidation loop were ineffective; removing them reduces production code by 35 lines. Atomic `GetOrAdd` preserves the prefix comparer without adding locks or changing filtering rules. Regression coverage exercises concurrent cold starts and subsequent settings updates.

### Evidence

Reviewed head: `f9ddd3de39a7a8515d66f2df7fa7c39cb323fde6`; base: `5eb567a599c1a6fd9a704d79dda1418488a88526`.

- **September 21:** Release suite passed 312 tests with 18 existing skips using SDK 10.0.401, selected by the existing roll-forward policy. A temporary deterministic comparison against the base settings implementation matched 560,000 results across null/case/wildcard inputs, add/update/remove/clear/apply operations, and change notifications. No further source edits were needed.
- **September 21:** refreshed Windows-target solution restore plus direct/transitive NuGet vulnerability and deprecation checks found no affected packages. All nine SDK-style sample vulnerability audits passed. OSV found no issues across 28 manifests, including legacy MVC `packages.config`.
- **Same-head hosted CI, September 2–3:** all six push/PR builds and CLA passed. [Windows push](https://github.com/exceptionless/Exceptionless.Net/actions/runs/33711019029) ran 613 tests with 36 existing skips across net10.0/net472, packaged all 12 clients, and published to both CI feeds. [Windows PR](https://github.com/exceptionless/Exceptionless.Net/actions/runs/33711022334) passed independently. Both review threads are resolved.
- **Earlier validation on this change:** all nine SDK-style samples built; console, ASP.NET Core/Lambda endpoints, logging adapters, and Lambda serialization smoke checks passed. Blazor served HTML/framework assets; interactive browser execution was not covered. The devcontainer built with its frozen lockfile and booted successfully. Workflow lint and mocked publishing-path checks passed. Nine refreshed direct NuGet package archives passed hash/signature verification.
- The 328 original test identities/outcomes were retained; two passing event-filter regression cases were added. No tests were disabled by this PR. Framework targets and public signatures are unchanged.

Core reproduction commands:

```sh
dotnet test Exceptionless.Net.NonWindows.slnx -c Release
dotnet restore Exceptionless.Net.Windows.slnx -p:OS=Windows_NT -p:NuGetAuditMode=all --force-evaluate
OS=Windows_NT dotnet list Exceptionless.Net.Windows.slnx package --vulnerable --include-transitive --no-restore
OS=Windows_NT dotnet list Exceptionless.Net.Windows.slnx package --deprecated --include-transitive --no-restore
osv-scanner scan source -r .
```

On Windows, build and test `Exceptionless.Net.Windows.slnx` natively. Cross-target restore/build on macOS does not prove Windows runtime behavior. NuGet/OSV checks are not a container OS vulnerability scan.

### Upstream compatibility references

[log4net 3.4.0 and timeout changes](https://github.com/apache/logging-log4net/releases/tag/rel/3.4.0), [NLog 6.2](https://github.com/NLog/NLog/releases/tag/v6.2.0), [xUnit 4.0 migration](https://xunit.net/releases/v3/4.0.0), [Test SDK 18.9](https://github.com/microsoft/vstest/releases/tag/v18.9.0), [AWS Lambda](https://github.com/aws/aws-lambda-dotnet/blob/master/CHANGELOG.md), and [AWS SDK](https://github.com/aws/aws-sdk-net/blob/main/changelogs/SDK.CHANGELOG.2026.md).

</details>
