### PR TITLE
Add deployment environments to events

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ The definition of the word exceptionless is: to be without exception. [Exception
 
 ## Using Exceptionless
 
+Set the deployment environment once at startup, with an optional override on each event:
+
+```csharp
+client.Configuration.SetEnvironment("production");
+client.CreateLog("Deployment complete").SetEnvironment("staging").Submit();
+```
+
+The hosting integration falls back to `IHostEnvironment.EnvironmentName`. Explicit configuration wins; `Exceptionless:Environment` and `Exceptionless__Environment` are also supported. Names are trimmed, lowercased, and limited to 64 characters. Missing or invalid values remain unspecified. The top-level event `environment` is separate from machine diagnostics in `data.@environment`. Stacks and fixed versions remain shared across environments.
+
 Refer to the Exceptionless documentation here: [Exceptionless Docs](https://exceptionless.com/docs/).
 
 ## Getting Started (Development)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ client.Configuration.SetEnvironment("production");
 client.CreateLog("Deployment complete").SetEnvironment("staging").Submit();
 ```
 
-The hosting integration falls back to `IHostEnvironment.EnvironmentName`. Explicit configuration wins; `Exceptionless:Environment` and `Exceptionless__Environment` are also supported. Names are trimmed, lowercased, and limited to 64 characters. Missing or invalid values remain unspecified. The top-level event `environment` is separate from machine diagnostics in `data.@environment`. Stacks and fixed versions remain shared across environments.
+The hosting integration falls back to `IHostEnvironment.EnvironmentName`. Explicit configuration wins; `Exceptionless:Environment` and `Exceptionless__Environment` are also supported. .NET Framework applications can use the `Exceptionless:Environment` app setting or the `environment` attribute on the `<exceptionless>` configuration section. Names are trimmed, lowercased, and limited to 64 characters. Missing or invalid values remain unspecified. The top-level event `environment` is separate from machine diagnostics in `data.@environment`. Stacks and fixed versions remain shared across environments.
 
 Refer to the Exceptionless documentation here: [Exceptionless Docs](https://exceptionless.com/docs/).
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ client.Configuration.SetEnvironment("production");
 client.CreateLog("Deployment complete").SetEnvironment("staging").Submit();
 ```
 
-The hosting integration falls back to `IHostEnvironment.EnvironmentName`. Explicit configuration wins; `Exceptionless:Environment` and `Exceptionless__Environment` are also supported. .NET Framework applications can use the `Exceptionless:Environment` app setting or the `environment` attribute on the `<exceptionless>` configuration section. Names are trimmed, lowercased, and limited to 64 characters. Missing or invalid values remain unspecified. The top-level event `environment` is separate from machine diagnostics in `data.@environment`. Stacks and fixed versions remain shared across environments.
+The hosting integration falls back to `IHostEnvironment.EnvironmentName`. Explicit configuration wins; `Exceptionless:Environment` and `Exceptionless__Environment` are also supported. .NET Framework applications can use the `Exceptionless:Environment` app setting or the `environment` attribute on the `<exceptionless>` configuration section. Names are trimmed and limited to 64 characters, preserving the supplied casing. The server filters case-insensitively and normalizes aggregation keys. Missing or invalid values remain unspecified. The top-level event `environment` is separate from machine diagnostics in `data.@environment`. Stacks and fixed versions remain shared across environments.
 
 Refer to the Exceptionless documentation here: [Exceptionless Docs](https://exceptionless.com/docs/).
 

--- a/build/common.props
+++ b/build/common.props
@@ -41,7 +41,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.303" PrivateAssets="All"/>
     <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Exceptionless/Configuration/ExceptionlessConfiguration.cs
+++ b/src/Exceptionless/Configuration/ExceptionlessConfiguration.cs
@@ -27,6 +27,12 @@ namespace Exceptionless {
         /// <summary>Whether an environment was explicitly configured, including an invalid value that remains unspecified.</summary>
         public bool IsEnvironmentConfigured { get; private set; }
 
+        /// <summary>Applies a deployment environment fallback without replacing an explicitly configured value.</summary>
+        public void SetDefaultEnvironment(string environment) {
+            if (!IsEnvironmentConfigured)
+                _environment = Utility.DeploymentEnvironment.Normalize(environment);
+        }
+
         private const string DEFAULT_SERVER_URL = "https://collector.exceptionless.io";
         private const string DEFAULT_CONFIG_SERVER_URL = "https://config.exceptionless.io";
         private const string DEFAULT_HEARTBEAT_SERVER_URL = "https://heartbeat.exceptionless.io";

--- a/src/Exceptionless/Configuration/ExceptionlessConfiguration.cs
+++ b/src/Exceptionless/Configuration/ExceptionlessConfiguration.cs
@@ -13,6 +13,14 @@ using Exceptionless.Models;
 
 namespace Exceptionless {
     public class ExceptionlessConfiguration {
+        private string _environment;
+
+        /// <summary>The default deployment environment for every event.</summary>
+        public string Environment {
+            get => _environment;
+            set => _environment = Utility.DeploymentEnvironment.Normalize(value);
+        }
+
         private const string DEFAULT_SERVER_URL = "https://collector.exceptionless.io";
         private const string DEFAULT_CONFIG_SERVER_URL = "https://config.exceptionless.io";
         private const string DEFAULT_HEARTBEAT_SERVER_URL = "https://heartbeat.exceptionless.io";

--- a/src/Exceptionless/Configuration/ExceptionlessConfiguration.cs
+++ b/src/Exceptionless/Configuration/ExceptionlessConfiguration.cs
@@ -18,8 +18,14 @@ namespace Exceptionless {
         /// <summary>The default deployment environment for every event.</summary>
         public string Environment {
             get => _environment;
-            set => _environment = Utility.DeploymentEnvironment.Normalize(value);
+            set {
+                _environment = Utility.DeploymentEnvironment.Normalize(value);
+                IsEnvironmentConfigured = value != null;
+            }
         }
+
+        /// <summary>Whether an environment was explicitly configured, including an invalid value that remains unspecified.</summary>
+        public bool IsEnvironmentConfigured { get; private set; }
 
         private const string DEFAULT_SERVER_URL = "https://collector.exceptionless.io";
         private const string DEFAULT_CONFIG_SERVER_URL = "https://config.exceptionless.io";

--- a/src/Exceptionless/Configuration/ExceptionlessSection.cs
+++ b/src/Exceptionless/Configuration/ExceptionlessSection.cs
@@ -11,6 +11,9 @@ namespace Exceptionless {
         [ConfigurationProperty("apiKey", IsRequired = true)]
         public string ApiKey { get { return base["apiKey"] as string; } set { base["apiKey"] = value; } }
 
+        [ConfigurationProperty("environment")]
+        public string Environment { get { return base["environment"] as string; } set { base["environment"] = value; } }
+
         [ConfigurationProperty("serverUrl")]
         public string ServerUrl { get { return base["serverUrl"] as string; } set { base["serverUrl"] = value; } }
 

--- a/src/Exceptionless/Extensions/EventBuilderExtensions.cs
+++ b/src/Exceptionless/Extensions/EventBuilderExtensions.cs
@@ -4,6 +4,12 @@ using Exceptionless.Plugins.Default;
 
 namespace Exceptionless {
     public static class EventBuilderExtensions {
+        /// <summary>Overrides the deployment environment for this event.</summary>
+        public static EventBuilder SetEnvironment(this EventBuilder builder, string environment) {
+            builder.Target.Environment = environment;
+            return builder;
+        }
+
         /// <summary>
         /// Sets the user's identity (ie. email address, username, user id) that the event happened to.
         /// </summary>

--- a/src/Exceptionless/Extensions/ExceptionlessConfigurationExtensions.cs
+++ b/src/Exceptionless/Extensions/ExceptionlessConfigurationExtensions.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Configuration;
 #endif
 
 #if NET45
+using System.Collections.Specialized;
 using System.Configuration;
 using Exceptionless.Extensions;
 using Exceptionless.Utility;
@@ -293,8 +294,15 @@ namespace Exceptionless {
                 config.Resolver.GetLog().Error(typeof(ExceptionlessConfigurationExtensions), ex, String.Concat("Error retrieving configuration section: ", ex.Message));
             }
 
+            config.ReadFromConfigSection(section);
+        }
+
+        internal static void ReadFromConfigSection(this ExceptionlessConfiguration config, ExceptionlessSection section) {
             if (section == null)
                 return;
+
+            if (section.ElementInformation.Properties["environment"].ValueOrigin != PropertyValueOrigin.Default)
+                config.Environment = section.Environment;
 
             if (!section.Enabled)
                 config.Enabled = false;
@@ -385,18 +393,25 @@ namespace Exceptionless {
         /// </summary>
         /// <param name="config">The configuration object you want to apply the attribute settings to.</param>
         public static void ReadFromAppSettings(this ExceptionlessConfiguration config) {
-            string apiKey = ConfigurationManager.AppSettings["Exceptionless:ApiKey"];
+            config.ReadFromAppSettings(ConfigurationManager.AppSettings);
+        }
+
+        internal static void ReadFromAppSettings(this ExceptionlessConfiguration config, NameValueCollection settings) {
+            if (settings["Exceptionless:Environment"] != null)
+                config.Environment = settings["Exceptionless:Environment"];
+
+            string apiKey = settings["Exceptionless:ApiKey"];
             if (IsValidApiKey(apiKey))
                 config.ApiKey = apiKey;
 
-            if (Boolean.TryParse(ConfigurationManager.AppSettings["Exceptionless:Enabled"], out bool enabled) && !enabled)
+            if (Boolean.TryParse(settings["Exceptionless:Enabled"], out bool enabled) && !enabled)
                 config.Enabled = false;
 
-            string serverUrl = ConfigurationManager.AppSettings["Exceptionless:ServerUrl"];
+            string serverUrl = settings["Exceptionless:ServerUrl"];
             if (!String.IsNullOrEmpty(serverUrl))
                 config.ServerUrl = serverUrl;
 
-            string defaultTags = ConfigurationManager.AppSettings["Exceptionless:DefaultTags"];
+            string defaultTags = settings["Exceptionless:DefaultTags"];
             if (!String.IsNullOrEmpty(defaultTags))
                 foreach (var tag in defaultTags.SplitAndTrim(',').Where(tag => !String.IsNullOrEmpty(tag)))
                     config.DefaultTags.Add(tag);

--- a/src/Exceptionless/Extensions/ExceptionlessConfigurationExtensions.cs
+++ b/src/Exceptionless/Extensions/ExceptionlessConfigurationExtensions.cs
@@ -27,6 +27,11 @@ using Exceptionless.Utility;
 
 namespace Exceptionless {
     public static class ExceptionlessConfigurationExtensions {
+        /// <summary>Sets the default deployment environment for every event.</summary>
+        public static void SetEnvironment(this ExceptionlessConfiguration config, string environment) {
+            config.Environment = environment;
+        }
+
         private const string INSTALL_ID_KEY = "ExceptionlessInstallId";
 
         /// <summary>
@@ -412,6 +417,9 @@ namespace Exceptionless {
                 throw new ArgumentNullException(nameof(settings));
 
             var section = settings.GetSection("Exceptionless");
+            if (section["Environment"] != null) {
+                config.Environment = section["Environment"];
+            }
             if (Boolean.TryParse(section["Enabled"], out bool enabled) && !enabled)
                 config.Enabled = false;
 
@@ -483,6 +491,11 @@ namespace Exceptionless {
         /// </summary>
         /// <param name="config">The configuration object you want to apply the attribute settings to.</param>
         public static void ReadFromEnvironmentalVariables(this ExceptionlessConfiguration config) {
+            string environment = GetEnvironmentalVariable("Exceptionless:Environment") ?? GetEnvironmentalVariable("Exceptionless__Environment");
+            if (environment != null) {
+                config.Environment = environment;
+            }
+
             string apiKey = GetEnvironmentalVariable("Exceptionless:ApiKey") ?? GetEnvironmentalVariable("Exceptionless__ApiKey");
             if (IsValidApiKey(apiKey))
                 config.ApiKey = apiKey;

--- a/src/Exceptionless/Models/Client/Event.cs
+++ b/src/Exceptionless/Models/Client/Event.cs
@@ -4,6 +4,15 @@ using System.Collections.Generic;
 namespace Exceptionless.Models {
     [Json.JsonObject(NamingStrategyType = typeof(Json.Serialization.SnakeCaseNamingStrategy))]
     public class Event : IData {
+        private string _environment;
+
+        /// <summary>The deployment environment, such as production or staging.</summary>
+        [Json.JsonProperty(NullValueHandling = Json.NullValueHandling.Ignore)]
+        public string Environment {
+            get => _environment;
+            set => _environment = Utility.DeploymentEnvironment.Normalize(value);
+        }
+
         public Event() {
             Tags = new TagSet();
             Data = new DataDictionary();
@@ -60,7 +69,7 @@ namespace Exceptionless.Models {
         public string ReferenceId { get; set; }
 
         protected bool Equals(Event other) {
-            return string.Equals(Type, other.Type) && string.Equals(Source, other.Source) && Tags.CollectionEquals(other.Tags) && string.Equals(Message, other.Message) && string.Equals(Geo, other.Geo) && Value == other.Value && Equals(Data, other.Data);
+            return string.Equals(Environment, other.Environment) && string.Equals(Type, other.Type) && string.Equals(Source, other.Source) && Tags.CollectionEquals(other.Tags) && string.Equals(Message, other.Message) && string.Equals(Geo, other.Geo) && Value == other.Value && Equals(Data, other.Data);
         }
 
         public override bool Equals(object obj) {
@@ -84,6 +93,9 @@ namespace Exceptionless.Models {
                 hashCode = (hashCode * 397) ^ (Geo == null ? 0 : Geo.GetHashCode());
                 hashCode = (hashCode * 397) ^ Value.GetHashCode();
                 hashCode = (hashCode * 397) ^ (Data == null ? 0 : Data.GetCollectionHashCode(_exclusions));
+                if (Environment != null) {
+                    hashCode = (hashCode * 397) ^ Environment.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Exceptionless/Models/Client/Event.cs
+++ b/src/Exceptionless/Models/Client/Event.cs
@@ -16,7 +16,7 @@ namespace Exceptionless.Models {
             }
         }
 
-        internal bool HasEnvironmentOverride { get; private set; }
+        internal bool HasEnvironmentOverride { get; set; }
 
         public Event() {
             Tags = new TagSet();

--- a/src/Exceptionless/Models/Client/Event.cs
+++ b/src/Exceptionless/Models/Client/Event.cs
@@ -10,8 +10,13 @@ namespace Exceptionless.Models {
         [Json.JsonProperty(NullValueHandling = Json.NullValueHandling.Ignore)]
         public string Environment {
             get => _environment;
-            set => _environment = Utility.DeploymentEnvironment.Normalize(value);
+            set {
+                _environment = Utility.DeploymentEnvironment.Normalize(value);
+                HasEnvironmentOverride = value != null;
+            }
         }
+
+        internal bool HasEnvironmentOverride { get; private set; }
 
         public Event() {
             Tags = new TagSet();

--- a/src/Exceptionless/Plugins/Default/001_DeploymentEnvironmentPlugin.cs
+++ b/src/Exceptionless/Plugins/Default/001_DeploymentEnvironmentPlugin.cs
@@ -1,0 +1,9 @@
+namespace Exceptionless.Plugins.Default {
+    [Priority(1)]
+    public sealed class DeploymentEnvironmentPlugin : IEventPlugin {
+        public void Run(EventPluginContext context) {
+            if (!context.Event.HasEnvironmentOverride)
+                context.Event.Environment = context.Client.Configuration.Environment;
+        }
+    }
+}

--- a/src/Exceptionless/Plugins/Default/005_HandleAggregateExceptionsPlugin.cs
+++ b/src/Exceptionless/Plugins/Default/005_HandleAggregateExceptionsPlugin.cs
@@ -21,7 +21,10 @@ namespace Exceptionless.Plugins.Default {
                 ctx.SetException(ex);
 
                 var serializer = context.Resolver.GetJsonSerializer();
-                context.Client.SubmitEvent(serializer.Deserialize(serializer.Serialize(context.Event), typeof(Event)) as Event, ctx);
+                var child = serializer.Deserialize(serializer.Serialize(context.Event), typeof(Event)) as Event;
+                if (child != null)
+                    child.HasEnvironmentOverride = context.Event.HasEnvironmentOverride;
+                context.Client.SubmitEvent(child, ctx);
             }
 
             context.Cancel = true;

--- a/src/Exceptionless/Plugins/Default/015_ConfigurationDefaultsPlugin.cs
+++ b/src/Exceptionless/Plugins/Default/015_ConfigurationDefaultsPlugin.cs
@@ -2,7 +2,7 @@
     [Priority(15)]
     public class ConfigurationDefaultsPlugin : IEventPlugin {
         public void Run(EventPluginContext context) {
-            if (context.Event.Environment == null) {
+            if (!context.Event.HasEnvironmentOverride) {
                 context.Event.Environment = context.Client.Configuration.Environment;
             }
 

--- a/src/Exceptionless/Plugins/Default/015_ConfigurationDefaultsPlugin.cs
+++ b/src/Exceptionless/Plugins/Default/015_ConfigurationDefaultsPlugin.cs
@@ -2,6 +2,10 @@
     [Priority(15)]
     public class ConfigurationDefaultsPlugin : IEventPlugin {
         public void Run(EventPluginContext context) {
+            if (context.Event.Environment == null) {
+                context.Event.Environment = context.Client.Configuration.Environment;
+            }
+
             foreach (string tag in context.Client.Configuration.DefaultTags)
                 context.Event.Tags.Add(tag);
 

--- a/src/Exceptionless/Plugins/Default/015_ConfigurationDefaultsPlugin.cs
+++ b/src/Exceptionless/Plugins/Default/015_ConfigurationDefaultsPlugin.cs
@@ -2,10 +2,6 @@
     [Priority(15)]
     public class ConfigurationDefaultsPlugin : IEventPlugin {
         public void Run(EventPluginContext context) {
-            if (!context.Event.HasEnvironmentOverride) {
-                context.Event.Environment = context.Client.Configuration.Environment;
-            }
-
             foreach (string tag in context.Client.Configuration.DefaultTags)
                 context.Event.Tags.Add(tag);
 

--- a/src/Exceptionless/Plugins/EventPluginManager.cs
+++ b/src/Exceptionless/Plugins/EventPluginManager.cs
@@ -24,6 +24,7 @@ namespace Exceptionless.Plugins {
         }
 
         public static void AddDefaultPlugins(ExceptionlessConfiguration config) {
+            config.AddPlugin<DeploymentEnvironmentPlugin>();
             config.AddPlugin<HandleAggregateExceptionsPlugin>();
             config.AddPlugin<EventExclusionPlugin>();
             config.AddPlugin<ConfigurationDefaultsPlugin>();

--- a/src/Exceptionless/Utility/DeploymentEnvironment.cs
+++ b/src/Exceptionless/Utility/DeploymentEnvironment.cs
@@ -1,11 +1,18 @@
 using System;
-using System.Linq;
 
 namespace Exceptionless.Utility {
     internal static class DeploymentEnvironment {
         public static string Normalize(string value) {
             string name = value?.Trim();
-            return String.IsNullOrEmpty(name) || name.Length > 64 || name.Any(Char.IsControl) ? null : name.ToLowerInvariant();
+            if (String.IsNullOrEmpty(name) || name.Length > 64)
+                return null;
+
+            foreach (char character in name) {
+                if (Char.IsControl(character))
+                    return null;
+            }
+
+            return name.ToLowerInvariant();
         }
     }
 }

--- a/src/Exceptionless/Utility/DeploymentEnvironment.cs
+++ b/src/Exceptionless/Utility/DeploymentEnvironment.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Linq;
+
+namespace Exceptionless.Utility {
+    internal static class DeploymentEnvironment {
+        public static string Normalize(string value) {
+            string name = value?.Trim();
+            return String.IsNullOrEmpty(name) || name.Length > 64 || name.Any(Char.IsControl) ? null : name.ToLowerInvariant();
+        }
+    }
+}

--- a/src/Exceptionless/Utility/DeploymentEnvironment.cs
+++ b/src/Exceptionless/Utility/DeploymentEnvironment.cs
@@ -12,7 +12,7 @@ namespace Exceptionless.Utility {
                     return null;
             }
 
-            return name.ToLowerInvariant();
+            return name;
         }
     }
 }

--- a/src/Platforms/Exceptionless.Extensions.Hosting/ExceptionlessExtensions.cs
+++ b/src/Platforms/Exceptionless.Extensions.Hosting/ExceptionlessExtensions.cs
@@ -30,7 +30,8 @@ namespace Exceptionless {
         /// Adds the given pre-configured <see cref="ExceptionlessClient"/> to the host builder and registers lifecycle hooks.
         /// </summary>
         public static IHostApplicationBuilder AddExceptionless(this IHostApplicationBuilder builder, ExceptionlessClient client) {
-            client.Configuration.Environment ??= builder.Environment.EnvironmentName;
+            if (!client.Configuration.IsEnvironmentConfigured)
+                client.Configuration.Environment = builder.Environment.EnvironmentName;
             builder.Services.AddExceptionless(client);
             builder.Services.AddExceptionlessLifetimeService();
             return builder;
@@ -91,7 +92,8 @@ namespace Exceptionless {
                     client.Configuration.ReadFromEnvironmentalVariables();
 
                 configure?.Invoke(client.Configuration);
-                client.Configuration.Environment ??= sp.GetService<IHostEnvironment>()?.EnvironmentName;
+                if (!client.Configuration.IsEnvironmentConfigured)
+                    client.Configuration.Environment = sp.GetService<IHostEnvironment>()?.EnvironmentName;
 
                 return client;
             });
@@ -112,7 +114,8 @@ namespace Exceptionless {
                     client.Configuration.ReadFromConfiguration(configuration);
 
                 configure?.Invoke(client.Configuration);
-                client.Configuration.Environment ??= sp.GetService<IHostEnvironment>()?.EnvironmentName;
+                if (!client.Configuration.IsEnvironmentConfigured)
+                    client.Configuration.Environment = sp.GetService<IHostEnvironment>()?.EnvironmentName;
 
                 return client;
             });

--- a/src/Platforms/Exceptionless.Extensions.Hosting/ExceptionlessExtensions.cs
+++ b/src/Platforms/Exceptionless.Extensions.Hosting/ExceptionlessExtensions.cs
@@ -60,7 +60,10 @@ namespace Exceptionless {
         /// <param name="client">The pre-configured <see cref="ExceptionlessClient"/> instance</param>
         /// <returns></returns>
         public static IServiceCollection AddExceptionless(this IServiceCollection services, ExceptionlessClient client) {
-            return services.AddSingleton(client);
+            return services.AddSingleton(sp => {
+                client.Configuration.Environment ??= sp.GetService<IHostEnvironment>()?.EnvironmentName;
+                return client;
+            });
         }
 
         /// <summary>
@@ -90,6 +93,7 @@ namespace Exceptionless {
                     client.Configuration.ReadFromEnvironmentalVariables();
 
                 configure?.Invoke(client.Configuration);
+                client.Configuration.Environment ??= sp.GetService<IHostEnvironment>()?.EnvironmentName;
 
                 return client;
             });
@@ -110,6 +114,7 @@ namespace Exceptionless {
                     client.Configuration.ReadFromConfiguration(configuration);
 
                 configure?.Invoke(client.Configuration);
+                client.Configuration.Environment ??= sp.GetService<IHostEnvironment>()?.EnvironmentName;
 
                 return client;
             });

--- a/src/Platforms/Exceptionless.Extensions.Hosting/ExceptionlessExtensions.cs
+++ b/src/Platforms/Exceptionless.Extensions.Hosting/ExceptionlessExtensions.cs
@@ -30,8 +30,7 @@ namespace Exceptionless {
         /// Adds the given pre-configured <see cref="ExceptionlessClient"/> to the host builder and registers lifecycle hooks.
         /// </summary>
         public static IHostApplicationBuilder AddExceptionless(this IHostApplicationBuilder builder, ExceptionlessClient client) {
-            if (!client.Configuration.IsEnvironmentConfigured)
-                client.Configuration.Environment = builder.Environment.EnvironmentName;
+            client.Configuration.SetDefaultEnvironment(builder.Environment.EnvironmentName);
             builder.Services.AddExceptionless(client);
             builder.Services.AddExceptionlessLifetimeService();
             return builder;
@@ -92,8 +91,7 @@ namespace Exceptionless {
                     client.Configuration.ReadFromEnvironmentalVariables();
 
                 configure?.Invoke(client.Configuration);
-                if (!client.Configuration.IsEnvironmentConfigured)
-                    client.Configuration.Environment = sp.GetService<IHostEnvironment>()?.EnvironmentName;
+                client.Configuration.SetDefaultEnvironment(sp.GetService<IHostEnvironment>()?.EnvironmentName);
 
                 return client;
             });
@@ -114,8 +112,7 @@ namespace Exceptionless {
                     client.Configuration.ReadFromConfiguration(configuration);
 
                 configure?.Invoke(client.Configuration);
-                if (!client.Configuration.IsEnvironmentConfigured)
-                    client.Configuration.Environment = sp.GetService<IHostEnvironment>()?.EnvironmentName;
+                client.Configuration.SetDefaultEnvironment(sp.GetService<IHostEnvironment>()?.EnvironmentName);
 
                 return client;
             });

--- a/src/Platforms/Exceptionless.Extensions.Hosting/ExceptionlessExtensions.cs
+++ b/src/Platforms/Exceptionless.Extensions.Hosting/ExceptionlessExtensions.cs
@@ -30,6 +30,7 @@ namespace Exceptionless {
         /// Adds the given pre-configured <see cref="ExceptionlessClient"/> to the host builder and registers lifecycle hooks.
         /// </summary>
         public static IHostApplicationBuilder AddExceptionless(this IHostApplicationBuilder builder, ExceptionlessClient client) {
+            client.Configuration.Environment ??= builder.Environment.EnvironmentName;
             builder.Services.AddExceptionless(client);
             builder.Services.AddExceptionlessLifetimeService();
             return builder;
@@ -60,10 +61,7 @@ namespace Exceptionless {
         /// <param name="client">The pre-configured <see cref="ExceptionlessClient"/> instance</param>
         /// <returns></returns>
         public static IServiceCollection AddExceptionless(this IServiceCollection services, ExceptionlessClient client) {
-            return services.AddSingleton(sp => {
-                client.Configuration.Environment ??= sp.GetService<IHostEnvironment>()?.EnvironmentName;
-                return client;
-            });
+            return services.AddSingleton(client);
         }
 
         /// <summary>

--- a/test/Exceptionless.TestHarness/Serializer/StorageSerializerTestBase.cs
+++ b/test/Exceptionless.TestHarness/Serializer/StorageSerializerTestBase.cs
@@ -27,6 +27,7 @@ namespace Exceptionless.Tests.Serializer {
             var ev= new Event {
                 Date = DateTime.Now,
                 Message = "Testing",
+                Environment = "production",
                 Type = Event.KnownTypes.Log,
                 Source = "StorageSerializer"
             };

--- a/test/Exceptionless.Tests/Configuration/DeploymentEnvironmentConfigurationTests.cs
+++ b/test/Exceptionless.Tests/Configuration/DeploymentEnvironmentConfigurationTests.cs
@@ -14,7 +14,7 @@ namespace Exceptionless.Tests.Configuration {
                 var mapped = ConfigurationManager.OpenMappedExeConfiguration(new ExeConfigurationFileMap { ExeConfigFilename = path }, ConfigurationUserLevel.None);
                 using var client = new ExceptionlessClient();
                 client.Configuration.ReadFromConfigSection((ExceptionlessSection)mapped.GetSection("exceptionless"));
-                Assert.Equal("staging", client.Configuration.Environment);
+                Assert.Equal("Staging", client.Configuration.Environment);
             } finally {
                 File.Delete(path);
             }
@@ -35,7 +35,7 @@ namespace Exceptionless.Tests.Configuration {
             client.Configuration.ReadFromAppSettings(new NameValueCollection());
             Assert.Equal("staging", client.Configuration.Environment);
             client.Configuration.ReadFromAppSettings(new NameValueCollection { ["Exceptionless:Environment"] = " Production " });
-            Assert.Equal("production", client.Configuration.Environment);
+            Assert.Equal("Production", client.Configuration.Environment);
         }
     }
 }

--- a/test/Exceptionless.Tests/Configuration/DeploymentEnvironmentConfigurationTests.cs
+++ b/test/Exceptionless.Tests/Configuration/DeploymentEnvironmentConfigurationTests.cs
@@ -1,0 +1,42 @@
+#if NET45
+using System.Collections.Specialized;
+using System.Configuration;
+using System.IO;
+using Xunit;
+
+namespace Exceptionless.Tests.Configuration {
+    public class DeploymentEnvironmentConfigurationTests {
+        [Fact]
+        public void ReadFromConfigSection_LoadsEnvironmentAttribute() {
+            string path = Path.GetTempFileName();
+            try {
+                File.WriteAllText(path, "<configuration><configSections><section name=\"exceptionless\" type=\"Exceptionless.ExceptionlessSection, Exceptionless\" /></configSections><exceptionless apiKey=\"test\" environment=\" Staging \" /></configuration>");
+                var mapped = ConfigurationManager.OpenMappedExeConfiguration(new ExeConfigurationFileMap { ExeConfigFilename = path }, ConfigurationUserLevel.None);
+                using var client = new ExceptionlessClient();
+                client.Configuration.ReadFromConfigSection((ExceptionlessSection)mapped.GetSection("exceptionless"));
+                Assert.Equal("staging", client.Configuration.Environment);
+            } finally {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void ReadFromConfigSection_MissingEnvironment_PreservesConfiguredValue() {
+            using var client = new ExceptionlessClient();
+            client.Configuration.Environment = "staging";
+            client.Configuration.ReadFromConfigSection(new ExceptionlessSection());
+            Assert.Equal("staging", client.Configuration.Environment);
+        }
+
+        [Fact]
+        public void ReadFromAppSettings_LoadsEnvironmentAndPreservesMissingSetting() {
+            using var client = new ExceptionlessClient();
+            client.Configuration.Environment = "staging";
+            client.Configuration.ReadFromAppSettings(new NameValueCollection());
+            Assert.Equal("staging", client.Configuration.Environment);
+            client.Configuration.ReadFromAppSettings(new NameValueCollection { ["Exceptionless:Environment"] = " Production " });
+            Assert.Equal("production", client.Configuration.Environment);
+        }
+    }
+}
+#endif

--- a/test/Exceptionless.Tests/Exceptionless.Tests.csproj
+++ b/test/Exceptionless.Tests/Exceptionless.Tests.csproj
@@ -51,6 +51,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="System.Threading.Tasks" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Runtime" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/test/Exceptionless.Tests/Platforms/HostingExtensionsTests.cs
+++ b/test/Exceptionless.Tests/Platforms/HostingExtensionsTests.cs
@@ -7,6 +7,19 @@ using Xunit;
 
 namespace Exceptionless.Tests.Platforms {
     public class HostingExtensionsTests {
+        [Theory]
+        [InlineData(null, "staging")]
+        [InlineData("production", "production")]
+        public void AddExceptionless_DeploymentEnvironment_UsesHostAsFallback(string? configuredEnvironment, string expectedEnvironment) {
+            var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings { EnvironmentName = "Staging" });
+            var client = new ExceptionlessClient();
+            client.Configuration.Environment = configuredEnvironment;
+            builder.AddExceptionless(client);
+
+            using var services = builder.Services.BuildServiceProvider();
+            Assert.Equal(expectedEnvironment, services.GetRequiredService<ExceptionlessClient>().Configuration.Environment);
+        }
+
         [Fact]
         public void AddExceptionless_WhenCalled_RegistersClientAndLifetimeService() {
             // Arrange

--- a/test/Exceptionless.Tests/Platforms/HostingExtensionsTests.cs
+++ b/test/Exceptionless.Tests/Platforms/HostingExtensionsTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 namespace Exceptionless.Tests.Platforms {
     public class HostingExtensionsTests {
         [Theory]
-        [InlineData(null, "staging")]
+        [InlineData(null, "Staging")]
         [InlineData("production", "production")]
         [InlineData("", null)]
         [InlineData(" ", null)]
@@ -32,12 +32,12 @@ namespace Exceptionless.Tests.Platforms {
             using var client = new ExceptionlessClient();
             var staging = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings { EnvironmentName = "Staging" });
             staging.AddExceptionless(client);
-            Assert.Equal("staging", client.Configuration.Environment);
+            Assert.Equal("Staging", client.Configuration.Environment);
             Assert.False(client.Configuration.IsEnvironmentConfigured);
 
             var production = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings { EnvironmentName = "Production" });
             production.AddExceptionless(client);
-            Assert.Equal("production", client.Configuration.Environment);
+            Assert.Equal("Production", client.Configuration.Environment);
             Assert.False(client.Configuration.IsEnvironmentConfigured);
         }
 

--- a/test/Exceptionless.Tests/Platforms/HostingExtensionsTests.cs
+++ b/test/Exceptionless.Tests/Platforms/HostingExtensionsTests.cs
@@ -28,6 +28,20 @@ namespace Exceptionless.Tests.Platforms {
         }
 
         [Fact]
+        public void AddExceptionless_HostFallback_DoesNotBecomeExplicitConfiguration() {
+            using var client = new ExceptionlessClient();
+            var staging = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings { EnvironmentName = "Staging" });
+            staging.AddExceptionless(client);
+            Assert.Equal("staging", client.Configuration.Environment);
+            Assert.False(client.Configuration.IsEnvironmentConfigured);
+
+            var production = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings { EnvironmentName = "Production" });
+            production.AddExceptionless(client);
+            Assert.Equal("production", client.Configuration.Environment);
+            Assert.False(client.Configuration.IsEnvironmentConfigured);
+        }
+
+        [Fact]
         public void AddExceptionless_ProvidedClient_RemainsOwnedByCaller() {
             var resolver = new Mock<IDependencyResolver>();
             using var client = new ExceptionlessClient(new ExceptionlessConfiguration(resolver.Object));

--- a/test/Exceptionless.Tests/Platforms/HostingExtensionsTests.cs
+++ b/test/Exceptionless.Tests/Platforms/HostingExtensionsTests.cs
@@ -1,8 +1,11 @@
 #if NET10_0_OR_GREATER
 using System.Linq;
+using Exceptionless.Configuration;
+using Exceptionless.Dependency;
 using Exceptionless.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Moq;
 using Xunit;
 
 namespace Exceptionless.Tests.Platforms {
@@ -18,6 +21,20 @@ namespace Exceptionless.Tests.Platforms {
 
             using var services = builder.Services.BuildServiceProvider();
             Assert.Equal(expectedEnvironment, services.GetRequiredService<ExceptionlessClient>().Configuration.Environment);
+        }
+
+        [Fact]
+        public void AddExceptionless_ProvidedClient_RemainsOwnedByCaller() {
+            var resolver = new Mock<IDependencyResolver>();
+            using var client = new ExceptionlessClient(new ExceptionlessConfiguration(resolver.Object));
+            var builder = Host.CreateApplicationBuilder();
+            builder.AddExceptionless(client);
+
+            using (var services = builder.Services.BuildServiceProvider()) {
+                Assert.Same(client, services.GetRequiredService<ExceptionlessClient>());
+            }
+
+            resolver.Verify(r => r.Dispose(), Times.Never);
         }
 
         [Fact]

--- a/test/Exceptionless.Tests/Platforms/HostingExtensionsTests.cs
+++ b/test/Exceptionless.Tests/Platforms/HostingExtensionsTests.cs
@@ -13,7 +13,11 @@ namespace Exceptionless.Tests.Platforms {
         [Theory]
         [InlineData(null, "staging")]
         [InlineData("production", "production")]
-        public void AddExceptionless_DeploymentEnvironment_UsesHostAsFallback(string? configuredEnvironment, string expectedEnvironment) {
+        [InlineData("", null)]
+        [InlineData(" ", null)]
+        [InlineData("prod\ninvalid", null)]
+        [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", null)]
+        public void AddExceptionless_DeploymentEnvironment_UsesHostAsFallback(string? configuredEnvironment, string? expectedEnvironment) {
             var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings { EnvironmentName = "Staging" });
             var client = new ExceptionlessClient();
             client.Configuration.Environment = configuredEnvironment;

--- a/test/Exceptionless.Tests/Plugins/001_DeploymentEnvironmentPluginTests.cs
+++ b/test/Exceptionless.Tests/Plugins/001_DeploymentEnvironmentPluginTests.cs
@@ -14,12 +14,12 @@ namespace Exceptionless.Tests.Plugins {
             var plugin = new DeploymentEnvironmentPlugin();
             var context = new EventPluginContext(client, new Event());
             plugin.Run(context);
-            Assert.Equal("production", context.Event.Environment);
+            Assert.Equal("Production", context.Event.Environment);
 
             var builder = client.CreateLog("test", "message").SetEnvironment(" Staging ");
             var overridden = new EventPluginContext(client, builder.Target);
             plugin.Run(overridden);
-            Assert.Equal("staging", overridden.Event.Environment);
+            Assert.Equal("Staging", overridden.Event.Environment);
             Assert.Empty(overridden.Event.Data);
         }
 

--- a/test/Exceptionless.Tests/Plugins/001_DeploymentEnvironmentPluginTests.cs
+++ b/test/Exceptionless.Tests/Plugins/001_DeploymentEnvironmentPluginTests.cs
@@ -1,0 +1,60 @@
+using Exceptionless.Models;
+using Exceptionless.Plugins;
+using Exceptionless.Plugins.Default;
+using Xunit;
+
+namespace Exceptionless.Tests.Plugins {
+    public class DeploymentEnvironmentPluginTests : PluginTestBase {
+        public DeploymentEnvironmentPluginTests(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public void Run_DeploymentEnvironment_UsesDefaultAndPreservesEventOverride() {
+            var client = CreateClient();
+            client.Configuration.SetEnvironment(" Production ");
+            var plugin = new DeploymentEnvironmentPlugin();
+            var context = new EventPluginContext(client, new Event());
+            plugin.Run(context);
+            Assert.Equal("production", context.Event.Environment);
+
+            var builder = client.CreateLog("test", "message").SetEnvironment(" Staging ");
+            var overridden = new EventPluginContext(client, builder.Target);
+            plugin.Run(overridden);
+            Assert.Equal("staging", overridden.Event.Environment);
+            Assert.Empty(overridden.Event.Data);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("prod\ninvalid")]
+        [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+        public void Run_InvalidDeploymentEnvironment_DoesNotUseDefault(string environment) {
+            var client = CreateClient();
+            client.Configuration.SetEnvironment("production");
+            var builder = client.CreateLog("test", "message").SetEnvironment(environment);
+            var context = new EventPluginContext(client, builder.Target);
+            new DeploymentEnvironmentPlugin().Run(context);
+            Assert.Null(context.Event.Environment);
+        }
+
+        [Theory]
+        [InlineData(null, "development", true)]
+        [InlineData("production", "production", false)]
+        [InlineData("", null, false)]
+        public void Pipeline_ExclusionCallbacks_SeeEffectiveEnvironment(string? environment, string? expectedEnvironment, bool cancelled) {
+            using var client = CreateClient();
+            client.Configuration.Environment = "development";
+            string? observedEnvironment = null;
+            client.Configuration.AddEventExclusion(ev => {
+                observedEnvironment = ev.Environment;
+                return ev.Environment != "development";
+            });
+            var context = new EventPluginContext(client, new Event { Type = Event.KnownTypes.FeatureUsage, Environment = environment });
+
+            EventPluginManager.Run(context);
+
+            Assert.Equal(expectedEnvironment, observedEnvironment);
+            Assert.Equal(cancelled, context.Cancel);
+        }
+    }
+}

--- a/test/Exceptionless.Tests/Plugins/005_HandleAggregateExceptionsPluginTests.cs
+++ b/test/Exceptionless.Tests/Plugins/005_HandleAggregateExceptionsPluginTests.cs
@@ -39,7 +39,7 @@ namespace Exceptionless.Tests.Plugins {
 
         [Theory]
         [InlineData(null, "production")]
-        [InlineData("Staging", "staging")]
+        [InlineData("Staging", "Staging")]
         [InlineData("", null)]
         [InlineData("prod\ninvalid", null)]
         [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", null)]

--- a/test/Exceptionless.Tests/Plugins/005_HandleAggregateExceptionsPluginTests.cs
+++ b/test/Exceptionless.Tests/Plugins/005_HandleAggregateExceptionsPluginTests.cs
@@ -37,23 +37,30 @@ namespace Exceptionless.Tests.Plugins {
             Assert.True(context.Cancel);
         }
 
-        [Fact]
-        public async Task MultipleInnerException() {
+        [Theory]
+        [InlineData(null, "production")]
+        [InlineData("Staging", "staging")]
+        [InlineData("", null)]
+        [InlineData("prod\ninvalid", null)]
+        [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", null)]
+        public async Task MultipleInnerException(string? environment, string? expectedEnvironment) {
             var submissionClient = new InMemorySubmissionClient();
-            var client = new ExceptionlessClient("LhhP1C9gijpSKCslHHCvwdSIz298twx271nTest");
+            using var client = new ExceptionlessClient("LhhP1C9gijpSKCslHHCvwdSIz298twx271nTest");
             client.Configuration.Resolver.Register<ISubmissionClient>(submissionClient);
+            client.Configuration.Environment = "production";
 
             var plugin = new HandleAggregateExceptionsPlugin();
             var exceptionOne = new Exception("one");
             var exceptionTwo = new Exception("two");
 
-            var context = new EventPluginContext(client, new Event());
+            var context = new EventPluginContext(client, new Event { Environment = environment });
             context.ContextData.SetException(new AggregateException(exceptionOne, exceptionTwo));
             plugin.Run(context);
             Assert.True(context.Cancel);
 
             await client.ProcessQueueAsync();
             Assert.Equal(2, submissionClient.Events.Count);
+            Assert.All(submissionClient.Events, ev => Assert.Equal(expectedEnvironment, ev.Environment));
         }
     }
 }

--- a/test/Exceptionless.Tests/Plugins/015_ConfigurationDefaultsPluginTests.cs
+++ b/test/Exceptionless.Tests/Plugins/015_ConfigurationDefaultsPluginTests.cs
@@ -8,36 +8,6 @@ using Xunit;
 
 namespace Exceptionless.Tests.Plugins {
     public class ConfigurationDefaultsPluginTests : PluginTestBase {
-        [Fact]
-        public void Run_DeploymentEnvironment_UsesDefaultAndPreservesEventOverride() {
-            var client = CreateClient();
-            client.Configuration.SetEnvironment(" Production ");
-            var plugin = new ConfigurationDefaultsPlugin();
-            var context = new EventPluginContext(client, new Event());
-            plugin.Run(context);
-            Assert.Equal("production", context.Event.Environment);
-
-            var builder = client.CreateLog("test", "message").SetEnvironment(" Staging ");
-            var overridden = new EventPluginContext(client, builder.Target);
-            plugin.Run(overridden);
-            Assert.Equal("staging", overridden.Event.Environment);
-            Assert.Empty(overridden.Event.Data);
-        }
-
-        [Theory]
-        [InlineData("")]
-        [InlineData(" ")]
-        [InlineData("prod\ninvalid")]
-        [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
-        public void Run_InvalidDeploymentEnvironment_DoesNotUseDefault(string environment) {
-            var client = CreateClient();
-            client.Configuration.SetEnvironment("production");
-            var builder = client.CreateLog("test", "message").SetEnvironment(environment);
-            var context = new EventPluginContext(client, builder.Target);
-            new ConfigurationDefaultsPlugin().Run(context);
-            Assert.Null(context.Event.Environment);
-        }
-
         public ConfigurationDefaultsPluginTests(ITestOutputHelper output) : base(output) { }
 
         [Fact]

--- a/test/Exceptionless.Tests/Plugins/015_ConfigurationDefaultsPluginTests.cs
+++ b/test/Exceptionless.Tests/Plugins/015_ConfigurationDefaultsPluginTests.cs
@@ -8,6 +8,22 @@ using Xunit;
 
 namespace Exceptionless.Tests.Plugins {
     public class ConfigurationDefaultsPluginTests : PluginTestBase {
+        [Fact]
+        public void Run_DeploymentEnvironment_UsesDefaultAndPreservesEventOverride() {
+            var client = CreateClient();
+            client.Configuration.SetEnvironment(" Production ");
+            var plugin = new ConfigurationDefaultsPlugin();
+            var context = new EventPluginContext(client, new Event());
+            plugin.Run(context);
+            Assert.Equal("production", context.Event.Environment);
+
+            var builder = client.CreateLog("test", "message").SetEnvironment(" Staging ");
+            var overridden = new EventPluginContext(client, builder.Target);
+            plugin.Run(overridden);
+            Assert.Equal("staging", overridden.Event.Environment);
+            Assert.Empty(overridden.Event.Data);
+        }
+
         public ConfigurationDefaultsPluginTests(ITestOutputHelper output) : base(output) { }
 
         [Fact]

--- a/test/Exceptionless.Tests/Plugins/015_ConfigurationDefaultsPluginTests.cs
+++ b/test/Exceptionless.Tests/Plugins/015_ConfigurationDefaultsPluginTests.cs
@@ -24,6 +24,20 @@ namespace Exceptionless.Tests.Plugins {
             Assert.Empty(overridden.Event.Data);
         }
 
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("prod\ninvalid")]
+        [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+        public void Run_InvalidDeploymentEnvironment_DoesNotUseDefault(string environment) {
+            var client = CreateClient();
+            client.Configuration.SetEnvironment("production");
+            var builder = client.CreateLog("test", "message").SetEnvironment(environment);
+            var context = new EventPluginContext(client, builder.Target);
+            new ConfigurationDefaultsPlugin().Run(context);
+            Assert.Null(context.Event.Environment);
+        }
+
         public ConfigurationDefaultsPluginTests(ITestOutputHelper output) : base(output) { }
 
         [Fact]

--- a/test/Exceptionless.Tests/Plugins/910_DuplicateCheckerPluginTests.cs
+++ b/test/Exceptionless.Tests/Plugins/910_DuplicateCheckerPluginTests.cs
@@ -14,6 +14,21 @@ using Exceptionless.Extensions;
 namespace Exceptionless.Tests.Plugins {
     public class DuplicateCheckerPluginTests : PluginTestBase {
         public DuplicateCheckerPluginTests(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public void Run_SameEventAcrossEnvironments_OnlyMergesWithinEnvironment() {
+            var client = CreateClient();
+            using (var plugin = new DuplicateCheckerPlugin(TimeSpan.FromMinutes(1))) {
+                foreach (bool duplicate in new[] { false, true }) {
+                    foreach (string environment in new[] { "production", "staging", null }) {
+                        var builder = client.CreateLog("Environment test").SetEnvironment(environment);
+                        var context = new EventPluginContext(client, builder.Target, builder.PluginContextData);
+                        plugin.Run(context);
+                        Assert.Equal(duplicate, context.Cancel);
+                    }
+                }
+            }
+        }
         
         [Fact]
         public void CanRemoveDuplicateExceptions() {

--- a/test/Exceptionless.Tests/Plugins/910_DuplicateCheckerPluginTests.cs
+++ b/test/Exceptionless.Tests/Plugins/910_DuplicateCheckerPluginTests.cs
@@ -20,7 +20,7 @@ namespace Exceptionless.Tests.Plugins {
             var client = CreateClient();
             using (var plugin = new DuplicateCheckerPlugin(TimeSpan.FromMinutes(1))) {
                 foreach (bool duplicate in new[] { false, true }) {
-                    foreach (string environment in new[] { "production", "staging", null }) {
+                    foreach (string environment in new[] { "Production", "production", "staging", null }) {
                         var builder = client.CreateLog("Environment test").SetEnvironment(environment);
                         var context = new EventPluginContext(client, builder.Target, builder.PluginContextData);
                         plugin.Run(context);

--- a/test/Exceptionless.Tests/Serializer/Models/EventSerializerTests.cs
+++ b/test/Exceptionless.Tests/Serializer/Models/EventSerializerTests.cs
@@ -11,13 +11,14 @@ namespace Exceptionless.Tests.Serializer.Models {
             var model = new Event { Environment = " Production " };
             model.Data[Event.KnownDataKeys.EnvironmentInfo] = new EnvironmentInfo { MachineName = "worker-1" };
             string json = Serialize(model);
-            Assert.Contains("\"environment\":\"production\"", json);
+            Assert.Contains("\"environment\":\"Production\"", json);
             var result = Deserialize<Event>(json);
-            Assert.Equal("production", result.Environment);
+            Assert.Equal("Production", result.Environment);
             Assert.Equal("worker-1", result.GetEnvironmentInfo().MachineName);
             Assert.Null(new Event { Environment = new string('x', 65) }.Environment);
             Assert.Null(new Event { Environment = "  " }.Environment);
             Assert.NotEqual(new Event { Environment = "production" }, new Event { Environment = "staging" });
+            Assert.NotEqual(new Event { Environment = "Production" }, new Event { Environment = "production" });
         }
 
         /* lang=json */

--- a/test/Exceptionless.Tests/Serializer/Models/EventSerializerTests.cs
+++ b/test/Exceptionless.Tests/Serializer/Models/EventSerializerTests.cs
@@ -6,6 +6,20 @@ using Xunit;
 
 namespace Exceptionless.Tests.Serializer.Models {
     public class EventSerializerTests : SerializerTestBase {
+        [Fact]
+        public void Serialize_DeploymentEnvironment_RoundTripsSeparatelyFromRuntimeMetadata() {
+            var model = new Event { Environment = " Production " };
+            model.Data[Event.KnownDataKeys.EnvironmentInfo] = new EnvironmentInfo { MachineName = "worker-1" };
+            string json = Serialize(model);
+            Assert.Contains("\"environment\":\"production\"", json);
+            var result = Deserialize<Event>(json);
+            Assert.Equal("production", result.Environment);
+            Assert.Equal("worker-1", result.GetEnvironmentInfo().MachineName);
+            Assert.Null(new Event { Environment = new string('x', 65) }.Environment);
+            Assert.Null(new Event { Environment = "  " }.Environment);
+            Assert.NotEqual(new Event { Environment = "production" }, new Event { Environment = "staging" });
+        }
+
         /* lang=json */
         private const string MinimalJson = """{"type":"log","source":"app","date":"0001-01-01T00:00:00+00:00","tags":[],"message":null,"geo":null,"value":null,"count":null,"data":{},"reference_id":null}""";
         /* lang=json */


### PR DESCRIPTION
Adds `Configuration.Environment`, fluent `SetEnvironment(...)` helpers, and configuration/environment-variable support for deployment environments. Hosting integration falls back to `IHostEnvironment.EnvironmentName`; per-event settings override the default.

Environment values retain their supplied casing after trimming. Search and aggregation normalization happens on the server, which continues grouping the same error into one stack. Duplicate detection preserves distinct event payloads.

Validation: Linux, macOS, and Windows CI passed, including net472 configuration tests. Focused regressions cover invalid overrides, host defaults, reuse, caller-owned clients, aggregate exceptions, and exclusion callbacks. No breaking public APIs.

Updates the private SourceLink build dependency from 10.0.300 to 10.0.303 to unblock CI restore and address [CVE-2026-62900](https://github.com/dotnet/sourcelink/security/advisories/GHSA-23fw-v26w-5fgq). The patch was published August 11; it changes build tooling only and requires no application migration.

Deploy the server support before adopting the new SDK setting.

Related PRs: [Exceptionless #2570](https://github.com/exceptionless/Exceptionless/pull/2570), [Exceptionless.JavaScript #193](https://github.com/exceptionless/Exceptionless.JavaScript/pull/193).
